### PR TITLE
[PSDK-93] GHA For NPM Publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish Package to NPM
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### What changed? Why?
- GHA workflow is created to Publish package to NPM registry
- The corresponding GH Secret `NPM_TOKEN` has been created as well

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
