### PR TITLE
Refactor wallet creation to split default address creation

### DIFF
--- a/src/coinbase/tests/address_test.ts
+++ b/src/coinbase/tests/address_test.ts
@@ -16,14 +16,19 @@ import { InternalError } from "../errors";
 import { createAxiosMock } from "./utils";
 import Decimal from "decimal.js";
 
-const newEthAddress = ethers.Wallet.createRandom();
+// newAddressModel creates a new AddressModel with a random wallet ID and a random Ethereum address.
+export const newAddressModel = (walletId: string): AddressModel => {
+  const ethAddress = ethers.Wallet.createRandom();
 
-const VALID_ADDRESS_MODEL: AddressModel = {
-  address_id: newEthAddress.address,
-  network_id: Coinbase.networkList.BaseSepolia,
-  public_key: newEthAddress.publicKey,
-  wallet_id: randomUUID(),
+  return {
+    address_id: ethAddress.address,
+    network_id: Coinbase.networkList.BaseSepolia,
+    public_key: ethAddress.publicKey,
+    wallet_id: walletId,
+  };
 };
+
+const VALID_ADDRESS_MODEL = newAddressModel(randomUUID());
 
 const VALID_BALANCE_MODEL: BalanceModel = {
   amount: "1000000000000000000",
@@ -87,11 +92,11 @@ describe("Address", () => {
     expect(address).toBeInstanceOf(Address);
   });
 
-  it("should return the network ID", () => {
-    expect(address.getId()).toBe(newEthAddress.address);
+  it("should return the address ID", () => {
+    expect(address.getId()).toBe(VALID_ADDRESS_MODEL.address_id);
   });
 
-  it("should return the address ID", () => {
+  it("should return the network ID", () => {
     expect(address.getNetworkId()).toBe(VALID_ADDRESS_MODEL.network_id);
   });
 

--- a/src/coinbase/tests/wallet_test.ts
+++ b/src/coinbase/tests/wallet_test.ts
@@ -1,22 +1,27 @@
 import MockAdapter from "axios-mock-adapter";
 import * as bip39 from "bip39";
 import { randomUUID } from "crypto";
-import { AddressesApiFactory, WalletsApiFactory } from "../../client";
+import { Address as AddressModel, AddressesApiFactory, WalletsApiFactory } from "../../client";
 import { Coinbase } from "../coinbase";
+import { BASE_PATH } from "../../client/base";
 import { ArgumentError } from "../errors";
 import { Wallet } from "../wallet";
 import { createAxiosMock } from "./utils";
+import { newAddressModel } from "./address_test";
 
 const walletId = randomUUID();
+
+const DEFAULT_ADDRESS_MODEL = newAddressModel(walletId);
+
 export const VALID_WALLET_MODEL = {
-  id: randomUUID(),
+  id: walletId,
   network_id: Coinbase.networkList.BaseSepolia,
-  default_address: {
-    wallet_id: walletId,
-    address_id: "0xdeadbeef",
-    public_key: "0x1234567890",
-    network_id: Coinbase.networkList.BaseSepolia,
-  },
+  default_address: DEFAULT_ADDRESS_MODEL,
+};
+
+export const VALID_WALLET_MODEL_WITHOUT_DEFAULT_ADDRESS = {
+  id: walletId,
+  network_id: Coinbase.networkList.BaseSepolia,
 };
 
 describe("Wallet Class", () => {
@@ -31,24 +36,89 @@ describe("Wallet Class", () => {
 
   beforeAll(async () => {
     axiosMock = new MockAdapter(axiosInstance);
-    axiosMock.onPost().reply(200, VALID_WALLET_MODEL).onGet().reply(200, VALID_WALLET_MODEL);
-    wallet = await Wallet.init(VALID_WALLET_MODEL, client, seed, 2);
   });
 
   afterEach(() => {
     axiosMock.reset();
   });
 
-  describe("should initializes a new Wallet", () => {
+  describe(".create", () => {
+    beforeEach(async () => {
+      axiosMock
+        .onPost(BASE_PATH + "/v1/wallets")
+        .reply(200, VALID_WALLET_MODEL_WITHOUT_DEFAULT_ADDRESS);
+
+      axiosMock
+        .onPost(BASE_PATH + "/v1/wallets/" + VALID_WALLET_MODEL.id + "/addresses")
+        .reply(200, DEFAULT_ADDRESS_MODEL);
+
+      // Mock reloading the wallet after default address is created.
+      axiosMock
+        .onGet(BASE_PATH + "/v1/wallets/" + VALID_WALLET_MODEL.id)
+        .reply(200, VALID_WALLET_MODEL);
+
+      wallet = await Wallet.create(client);
+    });
+
     it("should return a Wallet instance", async () => {
       expect(wallet).toBeInstanceOf(Wallet);
     });
+
     it("should return the correct wallet ID", async () => {
       expect(wallet.getId()).toBe(VALID_WALLET_MODEL.id);
     });
+
     it("should return the correct network ID", async () => {
       expect(wallet.getNetworkId()).toBe(Coinbase.networkList.BaseSepolia);
     });
+
+    it("should return the correct default address", async () => {
+      expect(wallet.defaultAddress()?.getId()).toBe(DEFAULT_ADDRESS_MODEL.address_id);
+    });
+  });
+
+  describe(".init", () => {
+    const existingSeed =
+      "hidden assault maple cheap gentle paper earth surprise trophy guide room tired";
+    const addressList = [
+      {
+        address_id: "0x23626702fdC45fc75906E535E38Ee1c7EC0C3213",
+        network_id: Coinbase.networkList.BaseSepolia,
+        public_key: "0x032c11a826d153bb8cf17426d03c3ffb74ea445b17362f98e1536f22bcce720772",
+        wallet_id: walletId,
+      },
+      {
+        address_id: "0x770603171A98d1CD07018F7309A1413753cA0018",
+        network_id: Coinbase.networkList.BaseSepolia,
+        public_key: "0x03c3379b488a32a432a4dfe91cc3a28be210eddc98b2005bb59a4cf4ed0646eb56",
+        wallet_id: walletId,
+      },
+    ];
+
+    beforeEach(async () => {
+      addressList.forEach(address => {
+        axiosMock
+          .onGet(
+            BASE_PATH + "/v1/wallets/" + VALID_WALLET_MODEL.id + "/addresses/" + address.address_id,
+          )
+          .replyOnce(200, address);
+      });
+
+      wallet = await Wallet.init(VALID_WALLET_MODEL, client, existingSeed, 2);
+    });
+
+    it("should return a Wallet instance", async () => {
+      expect(wallet).toBeInstanceOf(Wallet);
+    });
+
+    it("should return the correct wallet ID", async () => {
+      expect(wallet.getId()).toBe(VALID_WALLET_MODEL.id);
+    });
+
+    it("should return the correct network ID", async () => {
+      expect(wallet.getNetworkId()).toBe(Coinbase.networkList.BaseSepolia);
+    });
+
     it("should return the correct default address", async () => {
       expect(wallet.defaultAddress()?.getId()).toBe(VALID_WALLET_MODEL.default_address.address_id);
     });
@@ -62,13 +132,13 @@ describe("Wallet Class", () => {
         `Wallet{id: '${VALID_WALLET_MODEL.id}', networkId: '${Coinbase.networkList.BaseSepolia}'}`,
       );
     });
-  });
 
-  it("should throw an ArgumentError when the API client is not provided", async () => {
-    await expect(Wallet.init(VALID_WALLET_MODEL, undefined!)).rejects.toThrow(ArgumentError);
-  });
+    it("should throw an ArgumentError when the API client is not provided", async () => {
+      await expect(Wallet.init(VALID_WALLET_MODEL, undefined!)).rejects.toThrow(ArgumentError);
+    });
 
-  it("should throw an ArgumentError when the wallet model is not provided", async () => {
-    await expect(Wallet.init(undefined!, client)).rejects.toThrow(ArgumentError);
+    it("should throw an ArgumentError when the wallet model is not provided", async () => {
+      await expect(Wallet.init(undefined!, client)).rejects.toThrow(ArgumentError);
+    });
   });
 });

--- a/src/coinbase/user.ts
+++ b/src/coinbase/user.ts
@@ -1,6 +1,5 @@
 import { ApiClients } from "./types";
 import { User as UserModel } from "./../client/api";
-import { Coinbase } from "./coinbase";
 import { Wallet } from "./wallet";
 
 /**
@@ -32,13 +31,7 @@ export class User {
    * @returns the new Wallet
    */
   async createWallet(): Promise<Wallet> {
-    const payload = {
-      wallet: {
-        network_id: Coinbase.networkList.BaseSepolia,
-      },
-    };
-    const walletData = await this.client.wallet!.createWallet(payload);
-    return Wallet.init(walletData.data!, {
+    return Wallet.create({
       wallet: this.client.wallet!,
       address: this.client.address!,
     });


### PR DESCRIPTION


### What changed? Why?
This refactors wallet creation to split out default address creation to be in the `.create` method and not in the initialize method.

This parallels the ruby SDK changes made in:
https://github.com/coinbase/coinbase-sdk-ruby/pull/50

#### Qualified Impact
This makes changes to the wallet creation and initialization flow.
