### PR TITLE
Support tilde expansion in apiKey file path

### DIFF
--- a/src/coinbase/coinbase.ts
+++ b/src/coinbase/coinbase.ts
@@ -15,6 +15,7 @@ import { InternalError, InvalidAPIKeyFormat, InvalidConfiguration } from "./erro
 import { ApiClients } from "./types";
 import { User } from "./user";
 import { logApiResponse, registerAxiosInterceptors } from "./utils";
+import * as os from "os";
 
 /**
  * The Coinbase SDK.
@@ -111,6 +112,7 @@ export class Coinbase {
     debugging: boolean = false,
     basePath: string = BASE_PATH,
   ): Coinbase {
+    filePath = filePath.startsWith("~") ? filePath.replace("~", os.homedir()) : filePath;
     if (!fs.existsSync(filePath)) {
       throw new InvalidConfiguration(`Invalid configuration: file not found at ${filePath}`);
     }

--- a/src/coinbase/tests/coinbase_test.ts
+++ b/src/coinbase/tests/coinbase_test.ts
@@ -1,3 +1,5 @@
+import * as os from "os";
+import * as fs from "fs";
 import { randomUUID } from "crypto";
 import { APIError } from "../api_error";
 import { Coinbase } from "../coinbase";
@@ -11,6 +13,7 @@ import {
   walletsApiMock,
 } from "./utils";
 import { ethers } from "ethers";
+import path from "path";
 
 const PATH_PREFIX = "./src/coinbase/tests/config";
 
@@ -41,6 +44,17 @@ describe("Coinbase tests", () => {
     expect(() => Coinbase.configureFromJson(`${PATH_PREFIX}/not_parseable.json`)).toThrow(
       "Not able to parse the configuration file",
     );
+  });
+
+  it("should expand the tilde to the home directory", () => {
+    const configuration = fs.readFileSync(`${PATH_PREFIX}/coinbase_cloud_api_key.json`, "utf8");
+    const homeDir = os.homedir();
+    const relativePath = "~/test_config.json";
+    const expandedPath = path.join(homeDir, "test_config.json");
+    fs.writeFileSync(expandedPath, configuration, "utf8");
+    const cbInstance = Coinbase.configureFromJson(relativePath);
+    expect(cbInstance).toBeInstanceOf(Coinbase);
+    fs.unlinkSync(expandedPath);
   });
 
   describe("should able to interact with the API", () => {


### PR DESCRIPTION
### What changed? Why?
Adding support for tilde (~) expansion in apiKey file paths, allowing users to specify paths relative to their home directory.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
