### PR TITLE
[Chore] Fix GWei Transfers Asset Id

### DIFF
--- a/src/coinbase/address.ts
+++ b/src/coinbase/address.ts
@@ -120,10 +120,21 @@ export class Address {
    * @returns {Decimal} The balance of the asset.
    */
   async getBalance(assetId: string): Promise<Decimal> {
+    const normalizedAssetId = ((): string => {
+      switch (assetId) {
+        case Coinbase.assets.Gwei:
+          return Coinbase.assets.Eth;
+        case Coinbase.assets.Wei:
+          return Coinbase.assets.Eth;
+        default:
+          return assetId;
+      }
+    })();
+
     const response = await Coinbase.apiClients.address!.getAddressBalance(
       this.model.wallet_id,
       this.model.address_id,
-      assetId,
+      normalizedAssetId,
     );
 
     if (!response.data) {

--- a/src/coinbase/address.ts
+++ b/src/coinbase/address.ts
@@ -198,6 +198,7 @@ export class Address {
     const normalizedAssetId = ((): string => {
       switch (assetId) {
         case Coinbase.assets.Gwei:
+          return Coinbase.assets.Eth;
         case Coinbase.assets.Wei:
           return Coinbase.assets.Eth;
         default:

--- a/src/coinbase/tests/address_test.ts
+++ b/src/coinbase/tests/address_test.ts
@@ -101,7 +101,7 @@ describe("Address", () => {
     expect(Coinbase.apiClients.address!.getAddressBalance).toHaveBeenCalledWith(
       address.getWalletId(),
       address.getId(),
-      assetId,
+      Coinbase.assets.Eth,
     );
     expect(Coinbase.apiClients.address!.getAddressBalance).toHaveBeenCalledTimes(1);
   });
@@ -114,7 +114,7 @@ describe("Address", () => {
     expect(Coinbase.apiClients.address!.getAddressBalance).toHaveBeenCalledWith(
       address.getWalletId(),
       address.getId(),
-      assetId,
+      Coinbase.assets.Eth,
     );
     expect(Coinbase.apiClients.address!.getAddressBalance).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
### What changed? Why?
- Fix bug in `address.createTransfer` when asset id is `gwei`
- `gwei` is now replaced with `eth` as required by server

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
