### PR TITLE
Fix: Renaming trade methods in Wallet and Address Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ console.log(`Wallet successfully created: ${mainnetWallet}`);
 // Fund your Wallet's default Address with ETH from an external source.
 
 // Trade 0.00001 ETH to USDC
-let trade = await wallet.trade(0.00001, Coinbase.assets.Eth, Coinbase.assets.Usdc);
+let trade = await wallet.createTrade(0.00001, Coinbase.assets.Eth, Coinbase.assets.Usdc);
 
 console.log(`Second trade successfully completed: ${trade}`);
 ```

--- a/src/coinbase/tests/address_test.ts
+++ b/src/coinbase/tests/address_test.ts
@@ -472,7 +472,7 @@ describe("Address", () => {
 
       it("should return the broadcasted trade", async () => {
         Coinbase.apiClients.trade!.broadcastTrade = mockReturnValue(broadcastedTradeModel);
-        const result = await address.trade(amount, fromAssetId, toAssetId);
+        const result = await address.createTrade(amount, fromAssetId, toAssetId);
         const transaction = result.getTransaction();
         expect(transaction.getSignedPayload()).toEqual(signedPayload);
         expect(transaction.getStatus()).toEqual(TransactionStatus.BROADCAST);
@@ -490,7 +490,7 @@ describe("Address", () => {
 
       it("should sign the transaction with the key", async () => {
         Coinbase.apiClients.trade!.broadcastTrade = mockReturnValue(broadcastedTradeModel);
-        const result = await address.trade(amount, fromAssetId, toAssetId);
+        const result = await address.createTrade(amount, fromAssetId, toAssetId);
         const transaction = result.getTransaction();
         expect(transaction.sign).toHaveBeenCalledWith(key);
       });
@@ -504,7 +504,7 @@ describe("Address", () => {
 
         it("should return the broadcast trade", async () => {
           Coinbase.apiClients.trade!.broadcastTrade = mockReturnValue(broadcastedTradeModel);
-          await address.trade(amount, fromAssetId, toAssetId);
+          await address.createTrade(amount, fromAssetId, toAssetId);
           expect(Coinbase.apiClients.trade!.createTrade).toHaveBeenCalledWith(
             address.getWalletId(),
             address.getId(),
@@ -518,7 +518,7 @@ describe("Address", () => {
 
         it("should sign the transaction with the address key", async () => {
           Coinbase.apiClients.trade!.broadcastTrade = mockReturnValue(broadcastedTradeModel);
-          const result = await address.trade(amount, fromAssetId, toAssetId);
+          const result = await address.createTrade(amount, fromAssetId, toAssetId);
           const transaction = result.getTransaction();
           expect(transaction.sign).toHaveBeenCalledWith(key);
         });
@@ -533,7 +533,7 @@ describe("Address", () => {
 
         it("should return the broadcast trade", async () => {
           Coinbase.apiClients.trade!.broadcastTrade = mockReturnValue(broadcastedTradeModel);
-          await address.trade(amount, fromAssetId, toAssetId);
+          await address.createTrade(amount, fromAssetId, toAssetId);
           expect(Coinbase.apiClients.trade!.createTrade).toHaveBeenCalledWith(
             address.getWalletId(),
             address.getId(),
@@ -547,7 +547,7 @@ describe("Address", () => {
 
         it("should sign the transaction with the address key", async () => {
           Coinbase.apiClients.trade!.broadcastTrade = mockReturnValue(broadcastedTradeModel);
-          const result = await address.trade(amount, fromAssetId, toAssetId);
+          const result = await address.createTrade(amount, fromAssetId, toAssetId);
           const transaction = result.getTransaction();
           expect(transaction.sign).toHaveBeenCalledWith(key);
         });
@@ -564,7 +564,7 @@ describe("Address", () => {
 
         it("should return the broadcast trade", async () => {
           Coinbase.apiClients.trade!.broadcastTrade = mockReturnValue(broadcastedTradeModel);
-          await address.trade(amount, fromAssetId, toAssetId);
+          await address.createTrade(amount, fromAssetId, toAssetId);
           expect(Coinbase.apiClients.trade!.createTrade).toHaveBeenCalledWith(
             address.getWalletId(),
             address.getId(),
@@ -578,7 +578,7 @@ describe("Address", () => {
 
         it("should sign the transaction with the address key", async () => {
           Coinbase.apiClients.trade!.broadcastTrade = mockReturnValue(broadcastedTradeModel);
-          const result = await address.trade(amount, fromAssetId, toAssetId);
+          const result = await address.createTrade(amount, fromAssetId, toAssetId);
           const transaction = result.getTransaction();
           expect(transaction.sign).toHaveBeenCalledWith(key);
         });
@@ -597,7 +597,7 @@ describe("Address", () => {
         });
 
         it("should sign the trade transaction with the address key", async () => {
-          const trade = await address.trade(amount, fromAssetId, toAssetId);
+          const trade = await address.createTrade(amount, fromAssetId, toAssetId);
           const transaction = trade.getTransaction();
           expect(transaction.sign).toHaveBeenCalledWith(key);
         });
@@ -607,13 +607,13 @@ describe("Address", () => {
     describe("when the address cannot sign", () => {
       it("should raise an Error", async () => {
         const newAddress = new Address(VALID_ADDRESS_MODEL, null!);
-        await expect(newAddress.trade(new Decimal(100), "eth", "usdc")).rejects.toThrow(Error);
+        await expect(newAddress.createTrade(new Decimal(100), "eth", "usdc")).rejects.toThrow(Error);
       });
     });
 
     describe("when the to asset is unsupported", () => {
       it("should raise an ArgumentError", async () => {
-        await expect(address.trade(new Decimal(100), "eth", "XYZ")).rejects.toThrow(Error);
+        await expect(address.createTrade(new Decimal(100), "eth", "XYZ")).rejects.toThrow(Error);
       });
     });
 
@@ -623,7 +623,7 @@ describe("Address", () => {
         Coinbase.apiClients.address!.getAddressBalance = mockReturnValue({ amount: "0" });
       });
       it("should raise an Error", async () => {
-        await expect(address.trade(new Decimal(100), "eth", "usdc")).rejects.toThrow(Error);
+        await expect(address.createTrade(new Decimal(100), "eth", "usdc")).rejects.toThrow(Error);
       });
     });
   });

--- a/src/coinbase/tests/wallet_test.ts
+++ b/src/coinbase/tests/wallet_test.ts
@@ -740,10 +740,10 @@ describe("Wallet Class", () => {
         },
       } as TradeModel);
       const trade = Promise.resolve(tradeObject);
-      jest.spyOn(Address.prototype, "trade").mockReturnValue(trade);
+      jest.spyOn(Address.prototype, "createTrade").mockReturnValue(trade);
     });
     it("should create a trade from the default address", async () => {
-      const result = await wallet.trade(0.01, "eth", "usdc");
+      const result = await wallet.createTrade(0.01, "eth", "usdc");
       expect(result).toBeInstanceOf(Trade);
       expect(result.getAddressId()).toBe(tradeObject.getAddressId());
       expect(result.getWalletId()).toBe(tradeObject.getWalletId());

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -368,11 +368,11 @@ export class Wallet {
    * @throws {Error} If the private key is not loaded, or if the asset IDs are unsupported, or if there are insufficient funds.
    * @returns The Trade object.
    */
-  public async trade(amount: Amount, fromAssetId: string, toAssetId: string): Promise<Trade> {
+  public async createTrade(amount: Amount, fromAssetId: string, toAssetId: string): Promise<Trade> {
     if (!this.getDefaultAddress()) {
       throw new InternalError("Default address not found");
     }
-    return await this.getDefaultAddress()!.trade(amount, fromAssetId, toAssetId);
+    return await this.getDefaultAddress()!.createTrade(amount, fromAssetId, toAssetId);
   }
 
   /**


### PR DESCRIPTION
### What changed? Why?
Renaming `trade` methods to `createTrade` 
 

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
