### PR TITLE
[chore] CreateTransferOptions type for createtransfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Coinbase Node.js SDK Changelog
 
+## Pending
+
+### Added
+
+- `CreateTransferOptions` type
+
 ## [0.0.8] - 2024-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ console.log(`Faucet transaction: ${faucetTransaction}`);
 // Create a new Wallet to transfer funds to.
 // Then, we can transfer 0.00001 ETH out of the Wallet to another Wallet.
 const anotherWallet = await user.createWallet();
-const transfer = await wallet.createTransfer(0.00001, Coinbase.assets.Eth, anotherWallet);
+const transfer = await wallet.createTransfer({ amount: 0.00001, assetId: Coinbase.assets.Eth, destination: anotherWallet });
 ```
 
 

--- a/src/coinbase/address/wallet_address.ts
+++ b/src/coinbase/address/wallet_address.ts
@@ -10,7 +10,7 @@ import { ArgumentError, InternalError } from "../errors";
 import { FaucetTransaction } from "../faucet_transaction";
 import { Trade } from "../trade";
 import { Transfer } from "../transfer";
-import { Amount, Destination, TransferStatus } from "../types";
+import { Amount, Destination, TransferStatus, CreateTransferOptions } from "../types";
 import { delay } from "../utils";
 import { Wallet as WalletClass } from "../wallet";
 
@@ -154,23 +154,24 @@ export class WalletAddress extends Address {
   /**
    * Transfers the given amount of the given Asset to the given address. Only same-Network Transfers are supported.
    *
-   * @param amount - The amount of the Asset to send.
-   * @param assetId - The ID of the Asset to send. For Ether, Coinbase.assets.Eth, Coinbase.assets.Gwei, and Coinbase.assets.Wei supported.
-   * @param destination - The destination of the transfer. If a Wallet, sends to the Wallet's default address. If a String, interprets it as the address ID.
-   * @param intervalSeconds - The interval at which to poll the Network for Transfer status, in seconds.
-   * @param timeoutSeconds - The maximum amount of time to wait for the Transfer to complete, in seconds.
+   * @param options - The options to create the Transfer.
+   * @param options.amount - The amount of the Asset to send.
+   * @param options.assetId - The ID of the Asset to send. For Ether, Coinbase.assets.Eth, Coinbase.assets.Gwei, and Coinbase.assets.Wei supported.
+   * @param options.destination - The destination of the transfer. If a Wallet, sends to the Wallet's default address. If a String, interprets it as the address ID.
+   * @param options.timeoutSeconds - The maximum amount of time to wait for the Transfer to complete, in seconds.
+   * @param options.intervalSeconds - The interval at which to poll the Network for Transfer status, in seconds.
    * @returns The transfer object.
    * @throws {APIError} if the API request to create a Transfer fails.
    * @throws {APIError} if the API request to broadcast a Transfer fails.
    * @throws {Error} if the Transfer times out.
    */
-  public async createTransfer(
-    amount: Amount,
-    assetId: string,
-    destination: Destination,
-    intervalSeconds = 0.2,
+  public async createTransfer({
+    amount,
+    assetId,
+    destination,
     timeoutSeconds = 10,
-  ): Promise<Transfer> {
+    intervalSeconds = 0.2,
+  }: CreateTransferOptions): Promise<Transfer> {
     if (!Coinbase.useServerSigner && !this.key) {
       throw new InternalError("Cannot transfer from address without private key loaded");
     }

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -508,8 +508,8 @@ export enum ServerSignerStatus {
  */
 export type WalletCreateOptions = {
   networkId?: string;
-  intervalSeconds?: number;
   timeoutSeconds?: number;
+  intervalSeconds?: number;
 };
 
 /**
@@ -596,3 +596,14 @@ export enum StakeOptionsMode {
    */
   PARTIAL = "partial",
 }
+
+/**
+ * Options for creating a Transfer.
+ */
+export type CreateTransferOptions = {
+  amount: Amount;
+  assetId: string;
+  destination: Destination;
+  timeoutSeconds?: number;
+  intervalSeconds?: number;
+};

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -11,11 +11,11 @@ import { ArgumentError, InternalError } from "./errors";
 import { Transfer } from "./transfer";
 import {
   Amount,
-  Destination,
   SeedData,
   WalletData,
   ServerSignerStatus,
   WalletCreateOptions,
+  CreateTransferOptions,
 } from "./types";
 import { convertStringToHex, delay } from "./utils";
 import { FaucetTransaction } from "./faucet_transaction";
@@ -81,8 +81,8 @@ export class Wallet {
    */
   public static async create({
     networkId = Coinbase.networks.BaseSepolia,
-    intervalSeconds = 0.2,
     timeoutSeconds = 20,
+    intervalSeconds = 0.2,
   }: WalletCreateOptions = {}): Promise<Wallet> {
     const result = await Coinbase.apiClients.wallet!.createWallet({
       wallet: {
@@ -582,33 +582,34 @@ export class Wallet {
    * Transfers the given amount of the given Asset to the given address. Only same-Network Transfers are supported.
    * Currently only the default_address is used to source the Transfer.
    *
-   * @param amount - The amount of the Asset to send.
-   * @param assetId - The ID of the Asset to send.
-   * @param destination - The destination of the transfer. If a Wallet, sends to the Wallet's default address. If a String, interprets it as the address ID.
-   * @param intervalSeconds - The interval at which to poll the Network for Transfer status, in seconds.
-   * @param timeoutSeconds - The maximum amount of time to wait for the Transfer to complete, in seconds.
+   * @param options - The options to create the Transfer.
+   * @param options.amount - The amount of the Asset to send.
+   * @param options.assetId - The ID of the Asset to send.
+   * @param options.destination - The destination of the transfer. If a Wallet, sends to the Wallet's default address. If a String, interprets it as the address ID.
+   * @param options.timeoutSeconds - The maximum amount of time to wait for the Transfer to complete, in seconds.
+   * @param options.intervalSeconds - The interval at which to poll the Network for Transfer status, in seconds.
    * @returns The hash of the Transfer transaction.
    * @throws {APIError} if the API request to create a Transfer fails.
    * @throws {APIError} if the API request to broadcast a Transfer fails.
    * @throws {Error} if the Transfer times out.
    */
-  public async createTransfer(
-    amount: Amount,
-    assetId: string,
-    destination: Destination,
-    intervalSeconds = 0.2,
+  public async createTransfer({
+    amount,
+    assetId,
+    destination,
     timeoutSeconds = 10,
-  ): Promise<Transfer> {
+    intervalSeconds = 0.2,
+  }: CreateTransferOptions): Promise<Transfer> {
     if (!this.getDefaultAddress()) {
       throw new InternalError("Default address not found");
     }
-    return await this.getDefaultAddress()!.createTransfer(
+    return await this.getDefaultAddress()!.createTransfer({
       amount,
       assetId,
       destination,
-      intervalSeconds,
       timeoutSeconds,
-    );
+      intervalSeconds,
+    });
   }
 
   /**

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -86,11 +86,11 @@ describe("Coinbase SDK E2E Test", () => {
     expect(unhydratedWallet.getId()).toBe(walletId);
 
     console.log("Transfering 0.000000001 ETH from default address to second address...");
-    const transfer = await unhydratedWallet.createTransfer(
-      0.000000001,
-      Coinbase.assets.Eth,
-      wallet,
-    );
+    const transfer = await unhydratedWallet.createTransfer({
+      amount: 0.000000001,
+      assetId: Coinbase.assets.Eth,
+      destination: wallet,
+    });
     expect(await transfer.getStatus()).toBe(TransferStatus.COMPLETE);
     console.log(`Transferred 1 Gwei from ${unhydratedWallet} to ${wallet}`);
 

--- a/src/tests/user_test.ts
+++ b/src/tests/user_test.ts
@@ -232,11 +232,11 @@ describe("User Class", () => {
       );
       await expect(unhydratedWallet.createAddress()).rejects.toThrow(InternalError);
       await expect(
-        unhydratedWallet.createTransfer(
-          new Decimal("500000000000000000"),
-          Coinbase.assets.Eth,
-          address1,
-        ),
+        unhydratedWallet.createTransfer({
+          amount: new Decimal("500000000000000000"),
+          assetId: Coinbase.assets.Eth,
+          destination: address1,
+        }),
       ).rejects.toThrow(InternalError);
       expect(unhydratedWallet.canSign()).toBe(false);
     });

--- a/src/tests/wallet_address_test.ts
+++ b/src/tests/wallet_address_test.ts
@@ -202,13 +202,13 @@ describe("WalletAddress", () => {
     );
   });
 
-  describe(".createTransfer", () => {
+  describe("#createTransfer", () => {
     let weiAmount, destination, intervalSeconds, timeoutSeconds;
     let walletId, id;
 
     beforeEach(() => {
       weiAmount = new Decimal("500000000000000000");
-      destination = new WalletAddress(VALID_ADDRESS_MODEL,  key as unknown as ethers.Wallet);
+      destination = new WalletAddress(VALID_ADDRESS_MODEL, key as unknown as ethers.Wallet);
       intervalSeconds = 0.2;
       timeoutSeconds = 10;
       walletId = crypto.randomUUID();
@@ -243,13 +243,13 @@ describe("WalletAddress", () => {
         status: TransferStatus.COMPLETE,
       });
 
-      await address.createTransfer(
-        weiAmount,
-        Coinbase.assets.Wei,
+      await address.createTransfer({
+        amount: weiAmount,
+        assetId: Coinbase.assets.Wei,
         destination,
-        intervalSeconds,
         timeoutSeconds,
-      );
+        intervalSeconds,
+      });
 
       expect(Coinbase.apiClients.transfer!.createTransfer).toHaveBeenCalledTimes(1);
       expect(Coinbase.apiClients.transfer!.broadcastTransfer).toHaveBeenCalledTimes(1);
@@ -261,26 +261,26 @@ describe("WalletAddress", () => {
         new APIError("Failed to create transfer"),
       );
       await expect(
-        address.createTransfer(
-          weiAmount,
-          Coinbase.assets.Wei,
+        address.createTransfer({
+          amount: weiAmount,
+          assetId: Coinbase.assets.Wei,
           destination,
-          intervalSeconds,
           timeoutSeconds,
-        ),
+          intervalSeconds,
+        }),
       ).rejects.toThrow(APIError);
     });
 
     it("should throw an InternalError if the address key is not provided", async () => {
       const addressWithoutKey = new WalletAddress(VALID_ADDRESS_MODEL, null!);
       await expect(
-        addressWithoutKey.createTransfer(
-          weiAmount,
-          Coinbase.assets.Wei,
+        addressWithoutKey.createTransfer({
+          amount: weiAmount,
+          assetId: Coinbase.assets.Wei,
           destination,
-          intervalSeconds,
           timeoutSeconds,
-        ),
+          intervalSeconds,
+        }),
       ).rejects.toThrow(InternalError);
     });
 
@@ -302,13 +302,13 @@ describe("WalletAddress", () => {
         networkId: Coinbase.networks.BaseMainnet,
       });
       await expect(
-        address.createTransfer(
-          weiAmount,
-          Coinbase.assets.Wei,
-          invalidDestination,
-          intervalSeconds,
+        address.createTransfer({
+          amount: weiAmount,
+          assetId: Coinbase.assets.Wei,
+          destination: invalidDestination,
           timeoutSeconds,
-        ),
+          intervalSeconds,
+        }),
       ).rejects.toThrow(ArgumentError);
     });
 
@@ -318,13 +318,13 @@ describe("WalletAddress", () => {
         null!,
       );
       await expect(
-        address.createTransfer(
-          weiAmount,
-          Coinbase.assets.Wei,
-          invalidDestination,
-          intervalSeconds,
+        address.createTransfer({
+          amount: weiAmount,
+          assetId: Coinbase.assets.Wei,
+          destination: invalidDestination,
           timeoutSeconds,
-        ),
+          intervalSeconds,
+        }),
       ).rejects.toThrow(ArgumentError);
     });
 
@@ -334,13 +334,13 @@ describe("WalletAddress", () => {
         new APIError("Failed to broadcast transfer"),
       );
       await expect(
-        address.createTransfer(
-          weiAmount,
-          Coinbase.assets.Wei,
+        address.createTransfer({
+          amount: weiAmount,
+          assetId: Coinbase.assets.Wei,
           destination,
-          intervalSeconds,
           timeoutSeconds,
-        ),
+          intervalSeconds,
+        }),
       ).rejects.toThrow(APIError);
     });
 
@@ -358,26 +358,26 @@ describe("WalletAddress", () => {
       timeoutSeconds = 0.000002;
 
       await expect(
-        address.createTransfer(
-          weiAmount,
-          Coinbase.assets.Wei,
+        address.createTransfer({
+          amount: weiAmount,
+          assetId: Coinbase.assets.Wei,
           destination,
-          intervalSeconds,
           timeoutSeconds,
-        ),
+          intervalSeconds,
+        }),
       ).rejects.toThrow("Transfer timed out");
     });
 
     it("should throw an ArgumentError if there are insufficient funds", async () => {
       const insufficientAmount = new Decimal("10000000000000000000");
       await expect(
-        address.createTransfer(
-          insufficientAmount,
-          Coinbase.assets.Wei,
+        address.createTransfer({
+          amount: insufficientAmount,
+          assetId: Coinbase.assets.Wei,
           destination,
-          intervalSeconds,
           timeoutSeconds,
-        ),
+          intervalSeconds,
+        }),
       ).rejects.toThrow(ArgumentError);
     });
 
@@ -389,13 +389,13 @@ describe("WalletAddress", () => {
         status: TransferStatus.COMPLETE,
       });
 
-      await address.createTransfer(
-        weiAmount,
-        Coinbase.assets.Wei,
+      await address.createTransfer({
+        amount: weiAmount,
+        assetId: Coinbase.assets.Wei,
         destination,
-        intervalSeconds,
         timeoutSeconds,
-      );
+        intervalSeconds,
+      });
 
       expect(Coinbase.apiClients.transfer!.createTransfer).toHaveBeenCalledTimes(1);
       expect(Coinbase.apiClients.transfer!.getTransfer).toHaveBeenCalledTimes(1);
@@ -406,7 +406,7 @@ describe("WalletAddress", () => {
     });
   });
 
-  describe(".getTransfers", () => {
+  describe("#getTransfers", () => {
     beforeEach(() => {
       jest.clearAllMocks();
       const pages = ["abc", "def"];

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -66,7 +66,7 @@ describe("Wallet Class", () => {
     Coinbase.useServerSigner = false;
   });
 
-  describe(".createTransfer", () => {
+  describe("#createTransfer", () => {
     let weiAmount, destination, intervalSeconds, timeoutSeconds;
     let balanceModel: BalanceModel;
 
@@ -115,13 +115,13 @@ describe("Wallet Class", () => {
         status: TransferStatus.COMPLETE,
       });
 
-      await wallet.createTransfer(
-        weiAmount,
-        Coinbase.assets.Wei,
+      await wallet.createTransfer({
+        amount: weiAmount,
+        assetId: Coinbase.assets.Wei,
         destination,
-        intervalSeconds,
         timeoutSeconds,
-      );
+        intervalSeconds,
+      });
 
       expect(Coinbase.apiClients.transfer!.createTransfer).toHaveBeenCalledTimes(1);
       expect(Coinbase.apiClients.transfer!.broadcastTransfer).toHaveBeenCalledTimes(1);
@@ -133,13 +133,13 @@ describe("Wallet Class", () => {
         new APIError("Failed to create transfer"),
       );
       await expect(
-        wallet.createTransfer(
-          weiAmount,
-          Coinbase.assets.Wei,
+        wallet.createTransfer({
+          amount: weiAmount,
+          assetId: Coinbase.assets.Wei,
           destination,
-          intervalSeconds,
           timeoutSeconds,
-        ),
+          intervalSeconds,
+        }),
       ).rejects.toThrow(APIError);
     });
 
@@ -149,13 +149,13 @@ describe("Wallet Class", () => {
         new APIError("Failed to broadcast transfer"),
       );
       await expect(
-        wallet.createTransfer(
-          weiAmount,
-          Coinbase.assets.Wei,
+        wallet.createTransfer({
+          amount: weiAmount,
+          assetId: Coinbase.assets.Wei,
           destination,
-          intervalSeconds,
           timeoutSeconds,
-        ),
+          intervalSeconds,
+        }),
       ).rejects.toThrow(APIError);
     });
 
@@ -173,26 +173,26 @@ describe("Wallet Class", () => {
       timeoutSeconds = 0.000002;
 
       await expect(
-        wallet.createTransfer(
-          weiAmount,
-          Coinbase.assets.Wei,
+        wallet.createTransfer({
+          amount: weiAmount,
+          assetId: Coinbase.assets.Wei,
           destination,
-          intervalSeconds,
           timeoutSeconds,
-        ),
+          intervalSeconds,
+        }),
       ).rejects.toThrow("Transfer timed out");
     });
 
     it("should throw an ArgumentError if there are insufficient funds", async () => {
       const insufficientAmount = new Decimal("10000000000000000000");
       await expect(
-        wallet.createTransfer(
-          insufficientAmount,
-          Coinbase.assets.Wei,
+        wallet.createTransfer({
+          amount: insufficientAmount,
+          assetId: Coinbase.assets.Wei,
           destination,
-          intervalSeconds,
           timeoutSeconds,
-        ),
+          intervalSeconds,
+        }),
       ).rejects.toThrow(ArgumentError);
     });
 
@@ -204,13 +204,13 @@ describe("Wallet Class", () => {
         status: TransferStatus.COMPLETE,
       });
 
-      await wallet.createTransfer(
-        weiAmount,
-        Coinbase.assets.Wei,
+      await wallet.createTransfer({
+        amount: weiAmount,
+        assetId: Coinbase.assets.Wei,
         destination,
-        intervalSeconds,
         timeoutSeconds,
-      );
+        intervalSeconds,
+      });
 
       expect(Coinbase.apiClients.transfer!.createTransfer).toHaveBeenCalledTimes(1);
       expect(Coinbase.apiClients.transfer!.getTransfer).toHaveBeenCalledTimes(1);
@@ -233,7 +233,7 @@ describe("Wallet Class", () => {
       expect(Coinbase.apiClients.wallet!.getWallet).toHaveBeenCalledWith(walletId);
     });
 
-    describe(".getId", () => {
+    describe("#getId", () => {
       it("should return the correct wallet ID", async () => {
         expect(wallet.getId()).toBe(walletModel.id);
       });
@@ -284,7 +284,7 @@ describe("Wallet Class", () => {
       });
     });
 
-    describe(".getDefaultAddress", () => {
+    describe("#getDefaultAddress", () => {
       it("should return the correct default address", async () => {
         expect(wallet.getDefaultAddress()!.getId()).toBe(walletModel.default_address!.address_id);
       });
@@ -339,7 +339,7 @@ describe("Wallet Class", () => {
           server_signer_status: ServerSignerStatus.PENDING,
         });
 
-        await expect(Wallet.create({ intervalSeconds, timeoutSeconds })).rejects.toThrow(
+        await expect(Wallet.create({ timeoutSeconds, intervalSeconds })).rejects.toThrow(
           "Wallet creation timed out. Check status of your Server-Signer",
         );
         expect(Coinbase.apiClients.wallet!.createWallet).toHaveBeenCalledTimes(1);
@@ -448,7 +448,7 @@ describe("Wallet Class", () => {
     });
   });
 
-  describe(".export", () => {
+  describe("#export", () => {
     let walletId: string;
     let addressModel: AddressModel;
     let walletModel: WalletModel;
@@ -493,7 +493,7 @@ describe("Wallet Class", () => {
     });
   });
 
-  describe(".listBalances", () => {
+  describe("#listBalances", () => {
     beforeEach(() => {
       const mockBalanceResponse: AddressBalanceList = {
         data: [
@@ -530,7 +530,7 @@ describe("Wallet Class", () => {
     });
   });
 
-  describe(".getBalance", () => {
+  describe("#getBalance", () => {
     beforeEach(() => {
       const mockWalletBalance: BalanceModel = {
         amount: "5000000000000000000",
@@ -585,7 +585,7 @@ describe("Wallet Class", () => {
     });
   });
 
-  describe(".canSign", () => {
+  describe("#canSign", () => {
     let wallet;
     beforeAll(async () => {
       const mockAddressModel = newAddressModel(walletId);
@@ -631,7 +631,7 @@ describe("Wallet Class", () => {
     });
   });
 
-  describe(".saveSeed", () => {
+  describe("#saveSeed", () => {
     const seed = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
     let apiPrivateKey;
     const filePath = "seeds.json";
@@ -780,7 +780,7 @@ describe("Wallet Class", () => {
     });
   });
 
-  describe(".trade", () => {
+  describe("#trade", () => {
     let tradeObject;
     beforeAll(() => {
       tradeObject = new Trade({


### PR DESCRIPTION
### What changed? Why?
- This comes from feedback from a customer user research session
- `CreateTransferOptions` type added to use for optional input args for `createTransfer` instance methods
- `intervalSeconds` and `timeoutSeconds` ordering has been flipped

Note on Jest tests:
- We should be using `describe("#instanceMethodName` for instance methods and `describe(".staticMethodName` for static class methods

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
