### PR TITLE
Add explicit mode as a function param to staking related functions

### DIFF
--- a/src/coinbase/address/external_address.ts
+++ b/src/coinbase/address/external_address.ts
@@ -242,7 +242,7 @@ export class ExternalAddress extends Address {
     const newOptions = this.copyOptions(options);
 
     if (mode) {
-      newOptions["mode"] = mode;
+      newOptions.mode = mode;
     }
 
     const request = {
@@ -297,8 +297,8 @@ export class ExternalAddress extends Address {
 
     const newOptions = this.copyOptions(options);
 
-    newOptions["mode"] = mode;
-    newOptions["amount"] = asset.toAtomicAmount(new Decimal(amount.toString())).toString();
+    newOptions.mode = mode;
+    newOptions.amount = asset.toAtomicAmount(new Decimal(amount.toString())).toString();
 
     const request = {
       network_id: this.getNetworkId(),

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -333,7 +333,7 @@ export type ExternalAddressAPIClient = {
   /**
    * Request faucet funds to be sent to external address.
    *
-   * @param networkId - The ID of the wallet the address belongs to.
+   * @param networkId - The ID of the blockchain network
    * @param addressId - The onchain address of the address that is being fetched.
    * @param options - Override http request option.
    * @throws {APIError} If the request fails.
@@ -635,22 +635,6 @@ export type CoinbaseConfigureFromJsonOptions = {
 };
 
 /**
- * CoinbaseExternalAddressStakeOptions type definition.
- */
-export type CoinbaseExternalAddressStakeOptions = {
-  /**
-   * The mode type that you're trying to stake with.
-   * e.g.
-   */
-  mode?: StakeOptionsMode;
-
-  /**
-   * The amount to stake, unstake, or claim_stake for in a staking operation.
-   */
-  amount?: string;
-};
-
-/**
  * StakeOptionsMode type definition.
  */
 export enum StakeOptionsMode {
@@ -659,7 +643,7 @@ export enum StakeOptionsMode {
    */
   DEFAULT = "default",
   /**
-   * Partial represents Partial Ethereumn Staking mode.
+   * Partial represents Partial Ethereum Staking mode.
    */
   PARTIAL = "partial",
 }

--- a/src/tests/external_address_test.ts
+++ b/src/tests/external_address_test.ts
@@ -16,7 +16,7 @@ import {
 } from "../client";
 import Decimal from "decimal.js";
 import { ExternalAddress } from "../coinbase/address/external_address";
-import { CoinbaseExternalAddressStakeOptions, StakeOptionsMode } from "../coinbase/types";
+import { StakeOptionsMode } from "../coinbase/types";
 import { StakingOperation } from "../coinbase/staking_operation";
 import { Asset } from "../coinbase/asset";
 
@@ -92,11 +92,10 @@ describe("ExternalAddress", () => {
       Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
       Coinbase.apiClients.stake!.buildStakingOperation = mockReturnValue(STAKING_OPERATION_MODEL);
       Coinbase.apiClients.asset!.getAsset = getAssetMock();
-      const options: CoinbaseExternalAddressStakeOptions = { mode: StakeOptionsMode.PARTIAL };
       const op = await address.buildStakeOperation(
         new Decimal("0.0001"),
         Coinbase.assets.Eth,
-        options,
+        StakeOptionsMode.PARTIAL,
       );
 
       expect(Coinbase.apiClients.stake!.getStakingContext).toHaveBeenCalledWith({
@@ -437,7 +436,7 @@ describe("ExternalAddress", () => {
   });
 
   describe(".stakeableBalance", () => {
-    it("should return the stakeable balance successfully", async () => {
+    it("should return the stakeable balance successfully with default params", async () => {
       Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
       const stakeableBalance = await address.stakeableBalance(Coinbase.assets.Eth);
       expect(stakeableBalance).toEqual(new Decimal("3"));
@@ -450,10 +449,28 @@ describe("ExternalAddress", () => {
         },
       });
     });
+
+    it("should return the stakeable balance successfully in DEFAULT/PARTIAL mode", async () => {
+      Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
+      const stakeableBalance = await address.stakeableBalance(
+        Coinbase.assets.Eth,
+        StakeOptionsMode.PARTIAL,
+        {},
+      );
+      expect(stakeableBalance).toEqual(new Decimal("3"));
+      expect(Coinbase.apiClients.stake!.getStakingContext).toHaveBeenCalledWith({
+        address_id: address.getId(),
+        network_id: address.getNetworkId(),
+        asset_id: Coinbase.assets.Eth,
+        options: {
+          mode: StakeOptionsMode.PARTIAL,
+        },
+      });
+    });
   });
 
   describe(".unstakeableBalance", () => {
-    it("should return the unstakeable balance successfully", async () => {
+    it("should return the unstakeable balance successfully with default params", async () => {
       Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
       const unstakeableBalance = await address.unstakeableBalance(Coinbase.assets.Eth);
       expect(unstakeableBalance).toEqual(new Decimal("2"));
@@ -466,12 +483,48 @@ describe("ExternalAddress", () => {
         },
       });
     });
+
+    it("should return the unstakeable balance successfully in DEFAULT/PARTIAL mode", async () => {
+      Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
+      const unstakeableBalance = await address.unstakeableBalance(
+        Coinbase.assets.Eth,
+        StakeOptionsMode.PARTIAL,
+        {},
+      );
+      expect(unstakeableBalance).toEqual(new Decimal("2"));
+      expect(Coinbase.apiClients.stake!.getStakingContext).toHaveBeenCalledWith({
+        address_id: address.getId(),
+        network_id: address.getNetworkId(),
+        asset_id: Coinbase.assets.Eth,
+        options: {
+          mode: StakeOptionsMode.PARTIAL,
+        },
+      });
+    });
   });
 
   describe(".claimableBalance", () => {
-    it("should return the claimable balance successfully", async () => {
+    it("should return the claimable balance successfully with default params", async () => {
       Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
       const claimableBalance = await address.claimableBalance(Coinbase.assets.Eth);
+      expect(claimableBalance).toEqual(new Decimal("1"));
+      expect(Coinbase.apiClients.stake!.getStakingContext).toHaveBeenCalledWith({
+        address_id: address.getId(),
+        network_id: address.getNetworkId(),
+        asset_id: Coinbase.assets.Eth,
+        options: {
+          mode: StakeOptionsMode.DEFAULT,
+        },
+      });
+    });
+
+    it("should return the claimable balance successfully in DEFAULT/PARTIAL mode", async () => {
+      Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
+      const claimableBalance = await address.claimableBalance(
+        Coinbase.assets.Eth,
+        StakeOptionsMode.DEFAULT,
+        {},
+      );
       expect(claimableBalance).toEqual(new Decimal("1"));
       expect(Coinbase.apiClients.stake!.getStakingContext).toHaveBeenCalledWith({
         address_id: address.getId(),


### PR DESCRIPTION
### What changed? Why?

This PR helps add an explicit param `mode` and a separate map for options similar to what ruby client does to allow for a free form way of passing protocol and action specific options which I will need for the upcoming native eth work.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->

This is backwards compatible as I have good defaults for the newly added params.
