### PR TITLE
Expose address id for staking reward

### DIFF
--- a/src/coinbase/staking_reward.ts
+++ b/src/coinbase/staking_reward.ts
@@ -101,6 +101,15 @@ export class StakingReward {
   }
 
   /**
+   * Returns the onchain address of the StakingReward.
+   *
+   * @returns The onchain address.
+   */
+  public addressId(): string {
+    return this.model.address_id;
+  }
+
+  /**
    * Print the Staking Reward as a string.
    *
    * @returns The string representation of the Staking Reward.

--- a/src/tests/staking_reward_test.ts
+++ b/src/tests/staking_reward_test.ts
@@ -198,4 +198,23 @@ describe("StakingReward", () => {
       expect(rewardStr).toEqual("StakingReward { amount: '2.26' }");
     });
   });
+
+  describe(".addressId", () => {
+    it("should return the onchain address of the StakingReward", () => {
+      const reward = new StakingReward(
+        {
+          address_id: address.getId(),
+          date: "2024-05-03",
+          amount: "226",
+          state: StakingRewardStateEnum.Pending,
+          format: StakingRewardFormat.Usd,
+        },
+        asset,
+        StakingRewardFormat.Usd,
+      );
+
+      const addressId = reward.addressId();
+      expect(addressId).toEqual(address.getId());
+    });
+  });
 });


### PR DESCRIPTION
### What changed? Why?

For listing rewards of multiple addresses it will be helpful to be able to access the address to which the specific reward belongs to and be able to log it.

Example:

```
let rewards = await StakingReward.list("ethereum-mainnet", "eth", ["0x87Bf57c3d7B211a100ee4d00dee08435130A62fA", "0x15709cB3381251C362A63fF7cc39CB2c2029ae8E"], tenDaysAgo.toISOString(), now.toISOString());

> rewards.forEach(reward => {console.log(reward.date().toISOString() + " - " + reward.addressId() + " - " + reward.amount())});
2024-07-17T00:00:00.000Z - 0x15709cb3381251c362a63ff7cc39cb2c2029ae8e - 7.09
2024-07-18T00:00:00.000Z - 0x15709cb3381251c362a63ff7cc39cb2c2029ae8e - 10.22
2024-07-19T00:00:00.000Z - 0x15709cb3381251c362a63ff7cc39cb2c2029ae8e - 8.34
2024-07-20T00:00:00.000Z - 0x15709cb3381251c362a63ff7cc39cb2c2029ae8e - 7.23
2024-07-21T00:00:00.000Z - 0x15709cb3381251c362a63ff7cc39cb2c2029ae8e - 14.88
2024-07-12T00:00:00.000Z - 0x87bf57c3d7b211a100ee4d00dee08435130a62fa - 0.01
2024-07-13T00:00:00.000Z - 0x87bf57c3d7b211a100ee4d00dee08435130a62fa - 0.01
2024-07-14T00:00:00.000Z - 0x87bf57c3d7b211a100ee4d00dee08435130a62fa - 0.01
2024-07-15T00:00:00.000Z - 0x87bf57c3d7b211a100ee4d00dee08435130a62fa - 0.01
2024-07-16T00:00:00.000Z - 0x87bf57c3d7b211a100ee4d00dee08435130a62fa - 0.01
2024-07-17T00:00:00.000Z - 0x87bf57c3d7b211a100ee4d00dee08435130a62fa - 0.01
2024-07-18T00:00:00.000Z - 0x87bf57c3d7b211a100ee4d00dee08435130a62fa - 0.01
2024-07-19T00:00:00.000Z - 0x87bf57c3d7b211a100ee4d00dee08435130a62fa - 0.01
2024-07-20T00:00:00.000Z - 0x87bf57c3d7b211a100ee4d00dee08435130a62fa - 0.01
2024-07-21T00:00:00.000Z - 0x87bf57c3d7b211a100ee4d00dee08435130a62fa - 0.01
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
