### PR TITLE
[trivial] Fix signer to properly await

### DIFF
--- a/src/coinbase/staking_operation.ts
+++ b/src/coinbase/staking_operation.ts
@@ -140,10 +140,10 @@ export class StakingOperation {
    * @param key - The key used to sign the transactions.
    */
   public async sign(key: ethers.Wallet): Promise<void> {
-    this.transactions.forEach(tx => {
+    for (const tx of this.transactions) {
       if (!tx.isSigned()) {
-        tx.sign(key);
+        await tx.sign(key);
       }
-    });
+    }
   }
 }


### PR DESCRIPTION
### What changed? Why?

This PR fixes the staking operation wait function to properly await on signing.

As the function was not properly waiting on the tx to be signed, an attempt to subsequently broadcast would fail with an awkward etherjs error which is what we see in our dogfooding session.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
