### PR TITLE
[hotfix] Expose validator class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,4 @@ export * from "./coinbase/address/external_address";
 export * from "./coinbase/address/wallet_address";
 export * from "./coinbase/staking_operation";
 export * from "./coinbase/staking_reward";
+export * from "./coinbase/validator";


### PR DESCRIPTION
### What changed? Why?

For the `v0.0.10` release where we launched Dedicated ETH staking, we missed exposing the `Validator` class.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
