### PR TITLE
[PSDK-348] Trade Verb Support w/ MPC Server-Signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Coinbase Node.js SDK Changelog
 
+## Unreleased
+
+### Added
+
+- Support for trade with MPC Server-Signer
+- `CreateTradeOptions` type
+
 ## [0.0.12] - 2024-07-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ console.log(`Wallet successfully created: ${mainnetWallet}`);
 // Fund your Wallet's default Address with ETH from an external source.
 
 // Trade 0.00001 ETH to USDC
-let trade = await wallet.createTrade(0.00001, Coinbase.assets.Eth, Coinbase.assets.Usdc);
+let trade = await wallet.createTrade({ amount: 0.00001, fromAssetId: Coinbase.assets.Eth, toAssetId: Coinbase.assets.Usdc });
 
 console.log(`Second trade successfully completed: ${trade}`);
 ```

--- a/quickstart-template/trade_assets.js
+++ b/quickstart-template/trade_assets.js
@@ -1,6 +1,6 @@
 import { Coinbase } from "@coinbase/coinbase-sdk";
 
-let coinbase = Coinbase.configureFromJson({ filePath: '~/Downloads/cdp_api_key.json' });
+let coinbase = Coinbase.configureFromJson({ filePath: "~/Downloads/cdp_api_key.json" });
 let user = await coinbase.getDefaultUser();
 
 // Create a Wallet on base-mainnet to trade assets with.

--- a/src/coinbase/address/wallet_address.ts
+++ b/src/coinbase/address/wallet_address.ts
@@ -74,9 +74,9 @@ export class WalletAddress extends Address {
   }
 
   /**
-   * Returns all the transfers associated with the address.
+   * Returns all the trades associated with the address.
    *
-   * @returns The list of transfers.
+   * @returns The list of trades.
    */
   public async listTrades(): Promise<Trade[]> {
     const trades: Trade[] = [];
@@ -91,8 +91,8 @@ export class WalletAddress extends Address {
         page?.length ? page : undefined,
       );
 
-      response.data.data.forEach(transferModel => {
-        trades.push(new Trade(transferModel));
+      response.data.data.forEach(tradeModel => {
+        trades.push(new Trade(tradeModel));
       });
 
       if (response.data.has_more) {
@@ -252,14 +252,13 @@ export class WalletAddress extends Address {
    * Trades the given amount of the given Asset for another Asset. Only same-network Trades are supported.
    *
    * @param options = The options to create the Trade.
-   * @param options.amount - The amount of the Asset to send.
+   * @param options.amount - The amount of the From Asset to send.
    * @param options.fromAssetId - The ID of the Asset to trade from.
    * @param options.toAssetId - The ID of the Asset to trade to.
    * @param options.timeoutSeconds - The maximum amount of time to wait for the Trade to complete, in seconds.
    * @param options.intervalSeconds - The interval at which to poll the Network for Trade status, in seconds.
    * @returns The Trade object.
-   * @throws {APIError} if the API request to create a Trade fails.
-   * @throws {APIError} if the API request to broadcast a Trade fails.
+   * @throws {APIError} if the API request to create or broadcast a Trade fails.
    * @throws {Error} if the Trade times out.
    */
   public async createTrade({
@@ -364,7 +363,7 @@ export class WalletAddress extends Address {
    * @throws {Error} If the private key is not loaded, or if the asset IDs are unsupported, or if there are insufficient funds.
    */
   private async validateCanTrade(amount: Amount, fromAssetId: string) {
-    if (!this.canSign()) {
+    if (!Coinbase.useServerSigner && !this.key) {
       throw new Error("Cannot trade from address without private key loaded");
     }
     const currentBalance = await this.getBalance(fromAssetId);

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -718,3 +718,14 @@ export type CreateTransferOptions = {
   timeoutSeconds?: number;
   intervalSeconds?: number;
 };
+
+/**
+ * Options for creating a Trade.
+ */
+export type CreateTradeOptions = {
+  amount: Amount;
+  fromAssetId: string;
+  toAssetId: string;
+  timeoutSeconds?: number;
+  intervalSeconds?: number;
+};

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -16,8 +16,8 @@ import { FaucetTransaction } from "./faucet_transaction";
 import { Trade } from "./trade";
 import { Transfer } from "./transfer";
 import {
-  Amount,
   CreateTransferOptions,
+  CreateTradeOptions,
   SeedData,
   ServerSignerStatus,
   WalletCreateOptions,
@@ -275,18 +275,33 @@ export class Wallet {
   /**
    *  Trades the given amount of the given Asset for another Asset. Currently only the default address is used to source the Trade
    *
-   * @param amount - The amount of the Asset to send.
-   * @param fromAssetId - The ID of the Asset to trade from.
-   * @param toAssetId - The ID of the Asset to trade to.
+   * @param options - The options to create the Trade.
+   * @param options.amount - The amount of the Asset to send.
+   * @param options.fromAssetId - The ID of the Asset to trade from.
+   * @param options.toAssetId - The ID of the Asset to trade to.
+   * @param options.timeoutSeconds - The maximum amount of time to wait for the Trade to complete, in seconds.
+   * @param options.intervalSeconds - The interval at which to poll the Network for Trade status, in seconds.
    * @throws {InternalError} If the default address is not found.
    * @throws {Error} If the private key is not loaded, or if the asset IDs are unsupported, or if there are insufficient funds.
    * @returns The Trade object.
    */
-  public async createTrade(amount: Amount, fromAssetId: string, toAssetId: string): Promise<Trade> {
+  public async createTrade({
+    amount,
+    fromAssetId,
+    toAssetId,
+    timeoutSeconds = 10,
+    intervalSeconds = 0.2,
+  }: CreateTradeOptions): Promise<Trade> {
     if (!this.getDefaultAddress()) {
       throw new InternalError("Default address not found");
     }
-    return await this.getDefaultAddress()!.createTrade(amount, fromAssetId, toAssetId);
+    return await this.getDefaultAddress()!.createTrade({
+      amount: amount,
+      fromAssetId: fromAssetId,
+      toAssetId: toAssetId,
+      timeoutSeconds,
+      intervalSeconds,
+    });
   }
 
   /**

--- a/src/examples/trade_assets.js
+++ b/src/examples/trade_assets.js
@@ -8,7 +8,11 @@ async function tradeAssets() {
 
   // Fund the wallet's default address with ETH from an external source.
   // Trade 0.00001 ETH to USDC
-  const trade = await wallet.createTrade(0.00001, Coinbase.assets.Eth, Coinbase.assets.Usdc);
+  const trade = await wallet.createTrade({
+    amount: 0.00001,
+    fromAssetId: Coinbase.assets.Eth,
+    toAssetId: Coinbase.assets.Usdc,
+  });
   console.log(`Trade successfully completed: `, trade.toString());
 }
 

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -812,7 +812,7 @@ describe("Wallet Class", () => {
     });
   });
 
-  describe("#trade", () => {
+  describe("#createTrade", () => {
     const tradeObject = new Trade({
       network_id: Coinbase.networks.BaseSepolia,
       wallet_id: walletId,
@@ -829,16 +829,21 @@ describe("Wallet Class", () => {
 
     it("should throw an error when the wallet does not have a default address", async () => {
       const newWallet = Wallet.init(walletModel);
-      await expect(async () => await newWallet.createTrade(0.01, "eth", "usdc")).rejects.toThrow(
-        InternalError,
-      );
+      await expect(
+        async () =>
+          await newWallet.createTrade({ amount: 0.01, fromAssetId: "eth", toAssetId: "usdc" }),
+      ).rejects.toThrow(InternalError);
     });
 
     it("should create a trade from the default address", async () => {
       const trade = Promise.resolve(tradeObject);
       jest.spyOn(Wallet.prototype, "createTrade").mockReturnValue(trade);
       const wallet = await Wallet.create();
-      const result = await wallet.createTrade(0.01, "eth", "usdc");
+      const result = await wallet.createTrade({
+        amount: 0.01,
+        fromAssetId: "eth",
+        toAssetId: "usdc",
+      });
       expect(result).toBeInstanceOf(Trade);
       expect(result.getAddressId()).toBe(tradeObject.getAddressId());
       expect(result.getWalletId()).toBe(tradeObject.getWalletId());


### PR DESCRIPTION
### What changed? Why?
- Support for trade with MPC Server-Signer
- `CreateTradeOptions` type
-  Creating a trade promise now waits for the trade to land on chain to be consistent with transfers

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
This may impact all trade flows. Fix-forward, if necessary. 