### PR TITLE
[hotfix] Wallet.import Must Load List of Addresses during Hydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,13 +190,14 @@ await store(data);
 For convenience during testing, we provide a `saveSeed` method that stores the wallet's seed in your local file system. This is an insecure method of storing wallet seeds and should only be used for development purposes.
 
 ```typescript
-wallet.saveSeed(wallet);
+const seedFilePath = "";
+wallet.saveSeed(seedFilePath);
 ```
 
 To encrypt the saved data, set encrypt to true. Note that your CDP API key also serves as the encryption key for the data persisted locally. To re-instantiate wallets with encrypted data, ensure that your SDK is configured with the same API key when invoking `saveSeed` and `loadSeed`.
 
 ```typescript
-wallet.saveSeed(wallet, true);
+wallet.saveSeed(seedFilePath, true);
 ```
 
 The below code demonstrates how to re-instantiate a Wallet from the data export.
@@ -209,8 +210,6 @@ const importedWallet = await user.importWallet(data);
 To import Wallets that were persisted to your local file system using `saveSeed`, use the below code.
 
 ```typescript
-// Ensure your seed file path is updated
-const seedFilePath = "";
 const userWallet = await user.getWallet(wallet.getId());
 await userWallet.loadSeed(seedFilePath);
 ```

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -119,6 +119,7 @@ export class Wallet {
     }
     const walletModel = await Coinbase.apiClients.wallet!.getWallet(data.walletId);
     const wallet = Wallet.init(walletModel.data, data.seed);
+    await wallet.listAddresses();
     return wallet;
   }
 

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -784,6 +784,13 @@ describe("Wallet Class", () => {
     it("should return true for canSign when the wallet is initialized with a seed", () => {
       expect(wallet.canSign()).toBe(true);
     });
+
+    it("should be able to be imported", async () => {
+      const walletData = seedWallet.export();
+      const importedWallet = await Wallet.import(walletData);
+      expect(importedWallet).toBeInstanceOf(Wallet);
+      expect(Coinbase.apiClients.address!.listAddresses).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("#listBalances", () => {
@@ -974,7 +981,7 @@ describe("Wallet Class", () => {
     });
   });
 
-  describe(".loadSeed", () => {
+  describe("#loadSeed", () => {
     const seed = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
     let apiPrivateKey;
     const filePath = "seeds.json";


### PR DESCRIPTION
### What changed? Why?
- Resolves https://github.com/coinbase/coinbase-sdk-nodejs/issues/144
- Wallet hydration was silently failing due to `Wallet.import` not rehydrating the list of addresses for the wallet
- This adds the addresses fetch to `Wallet.import`

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
