### PR TITLE
[HistoricalBalances] add wallet level function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Coinbase Node.js SDK Changelog
 
+## [0.1.0]
+
+### Added
+
+- Add historical_balances function for wallet: listing historical balances for default address of the wallet.
+
 ## [0.0.16] - 2024-08-14
 
 ### Added

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -421,7 +421,7 @@ export class Wallet {
   }
 
   /**
-   * Lists the historical balances for the default address of wallet.
+   * Lists the historical balances for a given asset belonging to the default address of the wallet.
    *
    * @param options - The options to list historical balances.
    * @param options.assetId - The asset ID.

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -434,14 +434,14 @@ export class Wallet {
     limit,
     page,
   }: ListHistoricalBalancesOptions): Promise<ListHistoricalBalancesResult> {
-      if (!this.getDefaultAddress()) {
-        throw new InternalError("Default address not found");
-      }
-      return await this.getDefaultAddress()!.listHistoricalBalances({
-        assetId: assetId,
-        limit: limit,
-        page: page,
-      });
+    if (!this.getDefaultAddress()) {
+      throw new InternalError("Default address not found");
+    }
+    return await this.getDefaultAddress()!.listHistoricalBalances({
+      assetId: assetId,
+      limit: limit,
+      page: page,
+    });
   }
 
   /**

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -19,6 +19,8 @@ import {
   Amount,
   CreateTransferOptions,
   CreateTradeOptions,
+  ListHistoricalBalancesOptions,
+  ListHistoricalBalancesResult,
   SeedData,
   ServerSignerStatus,
   StakeOptionsMode,
@@ -416,6 +418,30 @@ export class Wallet {
       throw new InternalError("Default address not found");
     }
     return await this.getDefaultAddress()!.historicalStakingBalances(assetId, startTime, endTime);
+  }
+
+  /**
+   * Lists the historical balances for the default address of wallet.
+   *
+   * @param options - The options to list historical balances.
+   * @param options.assetId - The asset ID.
+   * @param options.limit - A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+   * @param options.page - A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+   * @returns The list of historical balance of the asset and next page token.
+   */
+  public async listHistoricalBalances({
+    assetId,
+    limit,
+    page,
+  }: ListHistoricalBalancesOptions): Promise<ListHistoricalBalancesResult> {
+      if (!this.getDefaultAddress()) {
+        throw new InternalError("Default address not found");
+      }
+      return await this.getDefaultAddress()!.listHistoricalBalances({
+        assetId: assetId,
+        limit: limit,
+        page: page,
+      });
   }
 
   /**

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -9,6 +9,7 @@ import { Wallet } from "../coinbase/wallet";
 import { ServerSignerStatus, StakeOptionsMode, TransferStatus } from "../coinbase/types";
 import {
   AddressBalanceList,
+  AddressHistoricalBalanceList,
   Address as AddressModel,
   Balance as BalanceModel,
   TransactionStatusEnum,
@@ -429,6 +430,62 @@ describe("Wallet Class", () => {
           Coinbase.networks.EthereumHolesky,
         );
       });
+    });
+  });
+
+  describe(".listHistoricalBalances", () => {
+    beforeEach(() => {
+      const mockHistoricalBalanceResponse: AddressHistoricalBalanceList = {
+        data: [
+          {
+            amount: "1000000",
+            block_hash: "0x0dadd465fb063ceb78babbb30abbc6bfc0730d0c57a53e8f6dc778dafcea568f",
+            block_height: "12345",
+            asset: {
+              asset_id: "usdc",
+              network_id: Coinbase.networks.EthereumHolesky,
+              decimals: 6,
+            },
+          },
+          {
+            amount: "5000000",
+            block_hash: "0x5c05a37dcb4910b22a775fc9480f8422d9d615ad7a6a0aa9d8778ff8cc300986",
+            block_height: "67890",
+            asset: {
+              asset_id: "usdc",
+              network_id: Coinbase.networks.EthereumHolesky,
+              decimals: 6,
+            },
+          },
+        ],
+        has_more: false,
+        next_page: "",
+      };
+      Coinbase.apiClients.externalAddress = externalAddressApiMock;
+      Coinbase.apiClients.externalAddress!.listAddressHistoricalBalance = mockReturnValue(
+        mockHistoricalBalanceResponse,
+      );
+    });
+    
+    it("should throw an error when the wallet does not have a default address", async () => {
+      const newWallet = Wallet.init(walletModel);
+      await expect(
+        async () => await newWallet.listHistoricalBalances({
+          assetId: Coinbase.assets.Usdc,
+        }),
+      ).rejects.toThrow(InternalError);
+    });
+
+    it("should successfully return historical balances", async () => {
+      const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
+      Coinbase.apiClients.asset!.getAsset = getAssetMock();
+      const response = await wallet.listHistoricalBalances({
+        assetId: Coinbase.assets.Usdc,
+      });
+      expect(response.historicalBalances.length).toEqual(2);
+      expect(response.historicalBalances[0].amount).toEqual(new Decimal(1));
+      expect(response.historicalBalances[1].amount).toEqual(new Decimal(5));
+      expect(response.nextPageToken).toEqual("");
     });
   });
 


### PR DESCRIPTION
### What changed? Why?
Add wallet level function for get historical balances: fetch historical balances for default address.



#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
