### PR TITLE
(feature) Validator Status Enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add historical_balances function for wallet: listing historical balances for default address of the wallet.
 - Add toAddressId() method to Transaction class
 - Remove "pending" status from StakingOperationStatusEnum
+- Add validator status enum
 
 ## [0.0.16] - 2024-08-14
 

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -950,6 +950,12 @@ export interface Network {
      * @memberof Network
      */
     'feature_set': FeatureSet;
+    /**
+     * The BIP44 path prefix for the network
+     * @type {string}
+     * @memberof Network
+     */
+    'address_path_prefix'?: string;
 }
 
 export const NetworkProtocolFamilyEnum = {
@@ -1998,7 +2004,6 @@ export interface ValidatorList {
  */
 
 export const ValidatorStatus = {
-    EthereumValidatorStatusUnspecified: 'ethereum_validator_status_unspecified',
     Provisioning: 'provisioning',
     Provisioned: 'provisioned',
     Deposited: 'deposited',
@@ -4273,54 +4278,6 @@ export class ServerSignersApi extends BaseAPI implements ServerSignersApiInterfa
 export const StakeApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
-         * Broadcast a staking operation.
-         * @summary Broadcast a staking operation
-         * @param {string} walletId The ID of the wallet the address belongs to.
-         * @param {string} addressId The ID of the address the staking operation belongs to.
-         * @param {string} stakingOperationId The ID of the staking operation to broadcast.
-         * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        broadcastStakingOperation: async (walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'walletId' is not null or undefined
-            assertParamExists('broadcastStakingOperation', 'walletId', walletId)
-            // verify required parameter 'addressId' is not null or undefined
-            assertParamExists('broadcastStakingOperation', 'addressId', addressId)
-            // verify required parameter 'stakingOperationId' is not null or undefined
-            assertParamExists('broadcastStakingOperation', 'stakingOperationId', stakingOperationId)
-            // verify required parameter 'broadcastStakingOperationRequest' is not null or undefined
-            assertParamExists('broadcastStakingOperation', 'broadcastStakingOperationRequest', broadcastStakingOperationRequest)
-            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/staking_operations/{staking_operation_id}/broadcast`
-                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
-                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)))
-                .replace(`{${"staking_operation_id"}}`, encodeURIComponent(String(stakingOperationId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(broadcastStakingOperationRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
          * Build a new staking operation
          * @summary Build a new staking operation
          * @param {BuildStakingOperationRequest} buildStakingOperationRequest 
@@ -4350,50 +4307,6 @@ export const StakeApiAxiosParamCreator = function (configuration?: Configuration
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(buildStakingOperationRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Create a new staking operation.
-         * @summary Create a new staking operation for an address
-         * @param {string} walletId The ID of the wallet the address belongs to.
-         * @param {string} addressId The ID of the address to create the staking operation for.
-         * @param {CreateStakingOperationRequest} createStakingOperationRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createStakingOperation: async (walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'walletId' is not null or undefined
-            assertParamExists('createStakingOperation', 'walletId', walletId)
-            // verify required parameter 'addressId' is not null or undefined
-            assertParamExists('createStakingOperation', 'addressId', addressId)
-            // verify required parameter 'createStakingOperationRequest' is not null or undefined
-            assertParamExists('createStakingOperation', 'createStakingOperationRequest', createStakingOperationRequest)
-            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/staking_operations`
-                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
-                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(createStakingOperationRequest, localVarRequestOptions, configuration)
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4597,48 +4510,6 @@ export const StakeApiAxiosParamCreator = function (configuration?: Configuration
                 options: localVarRequestOptions,
             };
         },
-        /**
-         * Get the latest state of a staking operation.
-         * @summary Get the latest state of a staking operation
-         * @param {string} walletId The ID of the wallet the address belongs to
-         * @param {string} addressId The ID of the address to fetch the staking operation for.
-         * @param {string} stakingOperationId The ID of the staking operation.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getStakingOperation: async (walletId: string, addressId: string, stakingOperationId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'walletId' is not null or undefined
-            assertParamExists('getStakingOperation', 'walletId', walletId)
-            // verify required parameter 'addressId' is not null or undefined
-            assertParamExists('getStakingOperation', 'addressId', addressId)
-            // verify required parameter 'stakingOperationId' is not null or undefined
-            assertParamExists('getStakingOperation', 'stakingOperationId', stakingOperationId)
-            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/staking_operations/{staking_operation_id}`
-                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
-                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)))
-                .replace(`{${"staking_operation_id"}}`, encodeURIComponent(String(stakingOperationId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
     }
 };
 
@@ -4650,22 +4521,6 @@ export const StakeApiFp = function(configuration?: Configuration) {
     const localVarAxiosParamCreator = StakeApiAxiosParamCreator(configuration)
     return {
         /**
-         * Broadcast a staking operation.
-         * @summary Broadcast a staking operation
-         * @param {string} walletId The ID of the wallet the address belongs to.
-         * @param {string} addressId The ID of the address the staking operation belongs to.
-         * @param {string} stakingOperationId The ID of the staking operation to broadcast.
-         * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StakingOperation>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.broadcastStakingOperation(walletId, addressId, stakingOperationId, broadcastStakingOperationRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['StakeApi.broadcastStakingOperation']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
          * Build a new staking operation
          * @summary Build a new staking operation
          * @param {BuildStakingOperationRequest} buildStakingOperationRequest 
@@ -4676,21 +4531,6 @@ export const StakeApiFp = function(configuration?: Configuration) {
             const localVarAxiosArgs = await localVarAxiosParamCreator.buildStakingOperation(buildStakingOperationRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['StakeApi.buildStakingOperation']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Create a new staking operation.
-         * @summary Create a new staking operation for an address
-         * @param {string} walletId The ID of the wallet the address belongs to.
-         * @param {string} addressId The ID of the address to create the staking operation for.
-         * @param {CreateStakingOperationRequest} createStakingOperationRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StakingOperation>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createStakingOperation(walletId, addressId, createStakingOperationRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['StakeApi.createStakingOperation']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
@@ -4755,21 +4595,6 @@ export const StakeApiFp = function(configuration?: Configuration) {
             const localVarOperationServerBasePath = operationServerMap['StakeApi.getStakingContext']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
-        /**
-         * Get the latest state of a staking operation.
-         * @summary Get the latest state of a staking operation
-         * @param {string} walletId The ID of the wallet the address belongs to
-         * @param {string} addressId The ID of the address to fetch the staking operation for.
-         * @param {string} stakingOperationId The ID of the staking operation.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StakingOperation>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getStakingOperation(walletId, addressId, stakingOperationId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['StakeApi.getStakingOperation']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
     }
 };
 
@@ -4781,19 +4606,6 @@ export const StakeApiFactory = function (configuration?: Configuration, basePath
     const localVarFp = StakeApiFp(configuration)
     return {
         /**
-         * Broadcast a staking operation.
-         * @summary Broadcast a staking operation
-         * @param {string} walletId The ID of the wallet the address belongs to.
-         * @param {string} addressId The ID of the address the staking operation belongs to.
-         * @param {string} stakingOperationId The ID of the staking operation to broadcast.
-         * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: any): AxiosPromise<StakingOperation> {
-            return localVarFp.broadcastStakingOperation(walletId, addressId, stakingOperationId, broadcastStakingOperationRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
          * Build a new staking operation
          * @summary Build a new staking operation
          * @param {BuildStakingOperationRequest} buildStakingOperationRequest 
@@ -4802,18 +4614,6 @@ export const StakeApiFactory = function (configuration?: Configuration, basePath
          */
         buildStakingOperation(buildStakingOperationRequest: BuildStakingOperationRequest, options?: any): AxiosPromise<StakingOperation> {
             return localVarFp.buildStakingOperation(buildStakingOperationRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Create a new staking operation.
-         * @summary Create a new staking operation for an address
-         * @param {string} walletId The ID of the wallet the address belongs to.
-         * @param {string} addressId The ID of the address to create the staking operation for.
-         * @param {CreateStakingOperationRequest} createStakingOperationRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: any): AxiosPromise<StakingOperation> {
-            return localVarFp.createStakingOperation(walletId, addressId, createStakingOperationRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * Fetch historical staking balances for given address.
@@ -4865,18 +4665,6 @@ export const StakeApiFactory = function (configuration?: Configuration, basePath
         getStakingContext(getStakingContextRequest: GetStakingContextRequest, options?: any): AxiosPromise<StakingContext> {
             return localVarFp.getStakingContext(getStakingContextRequest, options).then((request) => request(axios, basePath));
         },
-        /**
-         * Get the latest state of a staking operation.
-         * @summary Get the latest state of a staking operation
-         * @param {string} walletId The ID of the wallet the address belongs to
-         * @param {string} addressId The ID of the address to fetch the staking operation for.
-         * @param {string} stakingOperationId The ID of the staking operation.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: any): AxiosPromise<StakingOperation> {
-            return localVarFp.getStakingOperation(walletId, addressId, stakingOperationId, options).then((request) => request(axios, basePath));
-        },
     };
 };
 
@@ -4887,19 +4675,6 @@ export const StakeApiFactory = function (configuration?: Configuration, basePath
  */
 export interface StakeApiInterface {
     /**
-     * Broadcast a staking operation.
-     * @summary Broadcast a staking operation
-     * @param {string} walletId The ID of the wallet the address belongs to.
-     * @param {string} addressId The ID of the address the staking operation belongs to.
-     * @param {string} stakingOperationId The ID of the staking operation to broadcast.
-     * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StakeApiInterface
-     */
-    broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
-
-    /**
      * Build a new staking operation
      * @summary Build a new staking operation
      * @param {BuildStakingOperationRequest} buildStakingOperationRequest 
@@ -4908,18 +4683,6 @@ export interface StakeApiInterface {
      * @memberof StakeApiInterface
      */
     buildStakingOperation(buildStakingOperationRequest: BuildStakingOperationRequest, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
-
-    /**
-     * Create a new staking operation.
-     * @summary Create a new staking operation for an address
-     * @param {string} walletId The ID of the wallet the address belongs to.
-     * @param {string} addressId The ID of the address to create the staking operation for.
-     * @param {CreateStakingOperationRequest} createStakingOperationRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StakeApiInterface
-     */
-    createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
 
     /**
      * Fetch historical staking balances for given address.
@@ -4971,18 +4734,6 @@ export interface StakeApiInterface {
      */
     getStakingContext(getStakingContextRequest: GetStakingContextRequest, options?: RawAxiosRequestConfig): AxiosPromise<StakingContext>;
 
-    /**
-     * Get the latest state of a staking operation.
-     * @summary Get the latest state of a staking operation
-     * @param {string} walletId The ID of the wallet the address belongs to
-     * @param {string} addressId The ID of the address to fetch the staking operation for.
-     * @param {string} stakingOperationId The ID of the staking operation.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StakeApiInterface
-     */
-    getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
-
 }
 
 /**
@@ -4993,21 +4744,6 @@ export interface StakeApiInterface {
  */
 export class StakeApi extends BaseAPI implements StakeApiInterface {
     /**
-     * Broadcast a staking operation.
-     * @summary Broadcast a staking operation
-     * @param {string} walletId The ID of the wallet the address belongs to.
-     * @param {string} addressId The ID of the address the staking operation belongs to.
-     * @param {string} stakingOperationId The ID of the staking operation to broadcast.
-     * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StakeApi
-     */
-    public broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: RawAxiosRequestConfig) {
-        return StakeApiFp(this.configuration).broadcastStakingOperation(walletId, addressId, stakingOperationId, broadcastStakingOperationRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
      * Build a new staking operation
      * @summary Build a new staking operation
      * @param {BuildStakingOperationRequest} buildStakingOperationRequest 
@@ -5017,20 +4753,6 @@ export class StakeApi extends BaseAPI implements StakeApiInterface {
      */
     public buildStakingOperation(buildStakingOperationRequest: BuildStakingOperationRequest, options?: RawAxiosRequestConfig) {
         return StakeApiFp(this.configuration).buildStakingOperation(buildStakingOperationRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * Create a new staking operation.
-     * @summary Create a new staking operation for an address
-     * @param {string} walletId The ID of the wallet the address belongs to.
-     * @param {string} addressId The ID of the address to create the staking operation for.
-     * @param {CreateStakingOperationRequest} createStakingOperationRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StakeApi
-     */
-    public createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: RawAxiosRequestConfig) {
-        return StakeApiFp(this.configuration).createStakingOperation(walletId, addressId, createStakingOperationRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -5089,20 +4811,6 @@ export class StakeApi extends BaseAPI implements StakeApiInterface {
      */
     public getStakingContext(getStakingContextRequest: GetStakingContextRequest, options?: RawAxiosRequestConfig) {
         return StakeApiFp(this.configuration).getStakingContext(getStakingContextRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * Get the latest state of a staking operation.
-     * @summary Get the latest state of a staking operation
-     * @param {string} walletId The ID of the wallet the address belongs to
-     * @param {string} addressId The ID of the address to fetch the staking operation for.
-     * @param {string} stakingOperationId The ID of the staking operation.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StakeApi
-     */
-    public getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: RawAxiosRequestConfig) {
-        return StakeApiFp(this.configuration).getStakingOperation(walletId, addressId, stakingOperationId, options).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -6375,6 +6083,350 @@ export class ValidatorsApi extends BaseAPI implements ValidatorsApiInterface {
      */
     public listValidators(networkId: string, assetId: string, status?: ValidatorStatus, limit?: number, page?: string, options?: RawAxiosRequestConfig) {
         return ValidatorsApiFp(this.configuration).listValidators(networkId, assetId, status, limit, page, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
+ * WalletStakeApi - axios parameter creator
+ * @export
+ */
+export const WalletStakeApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * Broadcast a staking operation.
+         * @summary Broadcast a staking operation
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address the staking operation belongs to.
+         * @param {string} stakingOperationId The ID of the staking operation to broadcast.
+         * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        broadcastStakingOperation: async (walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('broadcastStakingOperation', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('broadcastStakingOperation', 'addressId', addressId)
+            // verify required parameter 'stakingOperationId' is not null or undefined
+            assertParamExists('broadcastStakingOperation', 'stakingOperationId', stakingOperationId)
+            // verify required parameter 'broadcastStakingOperationRequest' is not null or undefined
+            assertParamExists('broadcastStakingOperation', 'broadcastStakingOperationRequest', broadcastStakingOperationRequest)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/staking_operations/{staking_operation_id}/broadcast`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)))
+                .replace(`{${"staking_operation_id"}}`, encodeURIComponent(String(stakingOperationId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(broadcastStakingOperationRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Create a new staking operation.
+         * @summary Create a new staking operation for an address
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address to create the staking operation for.
+         * @param {CreateStakingOperationRequest} createStakingOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createStakingOperation: async (walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('createStakingOperation', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('createStakingOperation', 'addressId', addressId)
+            // verify required parameter 'createStakingOperationRequest' is not null or undefined
+            assertParamExists('createStakingOperation', 'createStakingOperationRequest', createStakingOperationRequest)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/staking_operations`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(createStakingOperationRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Get the latest state of a staking operation.
+         * @summary Get the latest state of a staking operation
+         * @param {string} walletId The ID of the wallet the address belongs to
+         * @param {string} addressId The ID of the address to fetch the staking operation for.
+         * @param {string} stakingOperationId The ID of the staking operation.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getStakingOperation: async (walletId: string, addressId: string, stakingOperationId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('getStakingOperation', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('getStakingOperation', 'addressId', addressId)
+            // verify required parameter 'stakingOperationId' is not null or undefined
+            assertParamExists('getStakingOperation', 'stakingOperationId', stakingOperationId)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/staking_operations/{staking_operation_id}`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)))
+                .replace(`{${"staking_operation_id"}}`, encodeURIComponent(String(stakingOperationId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * WalletStakeApi - functional programming interface
+ * @export
+ */
+export const WalletStakeApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = WalletStakeApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * Broadcast a staking operation.
+         * @summary Broadcast a staking operation
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address the staking operation belongs to.
+         * @param {string} stakingOperationId The ID of the staking operation to broadcast.
+         * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StakingOperation>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.broadcastStakingOperation(walletId, addressId, stakingOperationId, broadcastStakingOperationRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['WalletStakeApi.broadcastStakingOperation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Create a new staking operation.
+         * @summary Create a new staking operation for an address
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address to create the staking operation for.
+         * @param {CreateStakingOperationRequest} createStakingOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StakingOperation>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createStakingOperation(walletId, addressId, createStakingOperationRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['WalletStakeApi.createStakingOperation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Get the latest state of a staking operation.
+         * @summary Get the latest state of a staking operation
+         * @param {string} walletId The ID of the wallet the address belongs to
+         * @param {string} addressId The ID of the address to fetch the staking operation for.
+         * @param {string} stakingOperationId The ID of the staking operation.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StakingOperation>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getStakingOperation(walletId, addressId, stakingOperationId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['WalletStakeApi.getStakingOperation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * WalletStakeApi - factory interface
+ * @export
+ */
+export const WalletStakeApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = WalletStakeApiFp(configuration)
+    return {
+        /**
+         * Broadcast a staking operation.
+         * @summary Broadcast a staking operation
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address the staking operation belongs to.
+         * @param {string} stakingOperationId The ID of the staking operation to broadcast.
+         * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: any): AxiosPromise<StakingOperation> {
+            return localVarFp.broadcastStakingOperation(walletId, addressId, stakingOperationId, broadcastStakingOperationRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Create a new staking operation.
+         * @summary Create a new staking operation for an address
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address to create the staking operation for.
+         * @param {CreateStakingOperationRequest} createStakingOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: any): AxiosPromise<StakingOperation> {
+            return localVarFp.createStakingOperation(walletId, addressId, createStakingOperationRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Get the latest state of a staking operation.
+         * @summary Get the latest state of a staking operation
+         * @param {string} walletId The ID of the wallet the address belongs to
+         * @param {string} addressId The ID of the address to fetch the staking operation for.
+         * @param {string} stakingOperationId The ID of the staking operation.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: any): AxiosPromise<StakingOperation> {
+            return localVarFp.getStakingOperation(walletId, addressId, stakingOperationId, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * WalletStakeApi - interface
+ * @export
+ * @interface WalletStakeApi
+ */
+export interface WalletStakeApiInterface {
+    /**
+     * Broadcast a staking operation.
+     * @summary Broadcast a staking operation
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address the staking operation belongs to.
+     * @param {string} stakingOperationId The ID of the staking operation to broadcast.
+     * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WalletStakeApiInterface
+     */
+    broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
+
+    /**
+     * Create a new staking operation.
+     * @summary Create a new staking operation for an address
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address to create the staking operation for.
+     * @param {CreateStakingOperationRequest} createStakingOperationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WalletStakeApiInterface
+     */
+    createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
+
+    /**
+     * Get the latest state of a staking operation.
+     * @summary Get the latest state of a staking operation
+     * @param {string} walletId The ID of the wallet the address belongs to
+     * @param {string} addressId The ID of the address to fetch the staking operation for.
+     * @param {string} stakingOperationId The ID of the staking operation.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WalletStakeApiInterface
+     */
+    getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
+
+}
+
+/**
+ * WalletStakeApi - object-oriented interface
+ * @export
+ * @class WalletStakeApi
+ * @extends {BaseAPI}
+ */
+export class WalletStakeApi extends BaseAPI implements WalletStakeApiInterface {
+    /**
+     * Broadcast a staking operation.
+     * @summary Broadcast a staking operation
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address the staking operation belongs to.
+     * @param {string} stakingOperationId The ID of the staking operation to broadcast.
+     * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WalletStakeApi
+     */
+    public broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: RawAxiosRequestConfig) {
+        return WalletStakeApiFp(this.configuration).broadcastStakingOperation(walletId, addressId, stakingOperationId, broadcastStakingOperationRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Create a new staking operation.
+     * @summary Create a new staking operation for an address
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address to create the staking operation for.
+     * @param {CreateStakingOperationRequest} createStakingOperationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WalletStakeApi
+     */
+    public createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: RawAxiosRequestConfig) {
+        return WalletStakeApiFp(this.configuration).createStakingOperation(walletId, addressId, createStakingOperationRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Get the latest state of a staking operation.
+     * @summary Get the latest state of a staking operation
+     * @param {string} walletId The ID of the wallet the address belongs to
+     * @param {string} addressId The ID of the address to fetch the staking operation for.
+     * @param {string} stakingOperationId The ID of the staking operation.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WalletStakeApi
+     */
+    public getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: RawAxiosRequestConfig) {
+        return WalletStakeApiFp(this.configuration).getStakingOperation(walletId, addressId, stakingOperationId, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -626,7 +626,7 @@ export interface EthereumValidatorMetadata {
      * @type {string}
      * @memberof EthereumValidatorMetadata
      */
-    'withdrawl_address': string;
+    'withdrawal_address': string;
     /**
      * Whether the validator has been slashed.
      * @type {boolean}

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1946,11 +1946,11 @@ export interface Validator {
      */
     'asset_id': string;
     /**
-     * The status of the validator.
-     * @type {string}
+     * 
+     * @type {ValidatorStatus}
      * @memberof Validator
      */
-    'status': string;
+    'status': ValidatorStatus;
     /**
      * 
      * @type {ValidatorDetails}
@@ -1958,6 +1958,8 @@ export interface Validator {
      */
     'details'?: ValidatorDetails;
 }
+
+
 /**
  * @type ValidatorDetails
  * @export
@@ -1989,6 +1991,31 @@ export interface ValidatorList {
      */
     'next_page': string;
 }
+/**
+ * The status of the validator.
+ * @export
+ * @enum {string}
+ */
+
+export const ValidatorStatus = {
+    EthereumValidatorStatusUnspecified: 'ethereum_validator_status_unspecified',
+    Provisioning: 'provisioning',
+    Provisioned: 'provisioned',
+    Deposited: 'deposited',
+    PendingActivation: 'pending_activation',
+    Active: 'active',
+    Exiting: 'exiting',
+    Exited: 'exited',
+    WithdrawalAvailable: 'withdrawal_available',
+    WithdrawalComplete: 'withdrawal_complete',
+    ActiveSlashed: 'active_slashed',
+    ExitedSlashed: 'exited_slashed',
+    Reaped: 'reaped'
+} as const;
+
+export type ValidatorStatus = typeof ValidatorStatus[keyof typeof ValidatorStatus];
+
+
 /**
  * 
  * @export
@@ -6150,13 +6177,13 @@ export const ValidatorsApiAxiosParamCreator = function (configuration?: Configur
          * @summary List validators belonging to the CDP project
          * @param {string} networkId The ID of the blockchain network.
          * @param {string} assetId The symbol of the asset to get the validators for.
-         * @param {string} [status] A filter to list validators based on a status.
+         * @param {ValidatorStatus} [status] A filter to list validators based on a status.
          * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 50.
          * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listValidators: async (networkId: string, assetId: string, status?: string, limit?: number, page?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        listValidators: async (networkId: string, assetId: string, status?: ValidatorStatus, limit?: number, page?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'networkId' is not null or undefined
             assertParamExists('listValidators', 'networkId', networkId)
             // verify required parameter 'assetId' is not null or undefined
@@ -6228,13 +6255,13 @@ export const ValidatorsApiFp = function(configuration?: Configuration) {
          * @summary List validators belonging to the CDP project
          * @param {string} networkId The ID of the blockchain network.
          * @param {string} assetId The symbol of the asset to get the validators for.
-         * @param {string} [status] A filter to list validators based on a status.
+         * @param {ValidatorStatus} [status] A filter to list validators based on a status.
          * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 50.
          * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async listValidators(networkId: string, assetId: string, status?: string, limit?: number, page?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ValidatorList>> {
+        async listValidators(networkId: string, assetId: string, status?: ValidatorStatus, limit?: number, page?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ValidatorList>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.listValidators(networkId, assetId, status, limit, page, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['ValidatorsApi.listValidators']?.[localVarOperationServerIndex]?.url;
@@ -6267,13 +6294,13 @@ export const ValidatorsApiFactory = function (configuration?: Configuration, bas
          * @summary List validators belonging to the CDP project
          * @param {string} networkId The ID of the blockchain network.
          * @param {string} assetId The symbol of the asset to get the validators for.
-         * @param {string} [status] A filter to list validators based on a status.
+         * @param {ValidatorStatus} [status] A filter to list validators based on a status.
          * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 50.
          * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listValidators(networkId: string, assetId: string, status?: string, limit?: number, page?: string, options?: any): AxiosPromise<ValidatorList> {
+        listValidators(networkId: string, assetId: string, status?: ValidatorStatus, limit?: number, page?: string, options?: any): AxiosPromise<ValidatorList> {
             return localVarFp.listValidators(networkId, assetId, status, limit, page, options).then((request) => request(axios, basePath));
         },
     };
@@ -6302,14 +6329,14 @@ export interface ValidatorsApiInterface {
      * @summary List validators belonging to the CDP project
      * @param {string} networkId The ID of the blockchain network.
      * @param {string} assetId The symbol of the asset to get the validators for.
-     * @param {string} [status] A filter to list validators based on a status.
+     * @param {ValidatorStatus} [status] A filter to list validators based on a status.
      * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 50.
      * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ValidatorsApiInterface
      */
-    listValidators(networkId: string, assetId: string, status?: string, limit?: number, page?: string, options?: RawAxiosRequestConfig): AxiosPromise<ValidatorList>;
+    listValidators(networkId: string, assetId: string, status?: ValidatorStatus, limit?: number, page?: string, options?: RawAxiosRequestConfig): AxiosPromise<ValidatorList>;
 
 }
 
@@ -6339,14 +6366,14 @@ export class ValidatorsApi extends BaseAPI implements ValidatorsApiInterface {
      * @summary List validators belonging to the CDP project
      * @param {string} networkId The ID of the blockchain network.
      * @param {string} assetId The symbol of the asset to get the validators for.
-     * @param {string} [status] A filter to list validators based on a status.
+     * @param {ValidatorStatus} [status] A filter to list validators based on a status.
      * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 50.
      * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ValidatorsApi
      */
-    public listValidators(networkId: string, assetId: string, status?: string, limit?: number, page?: string, options?: RawAxiosRequestConfig) {
+    public listValidators(networkId: string, assetId: string, status?: ValidatorStatus, limit?: number, page?: string, options?: RawAxiosRequestConfig) {
         return ValidatorsApiFp(this.configuration).listValidators(networkId, assetId, status, limit, page, options).then((request) => request(this.axios, this.basePath));
     }
 }

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -950,12 +950,6 @@ export interface Network {
      * @memberof Network
      */
     'feature_set': FeatureSet;
-    /**
-     * The BIP44 path prefix for the network
-     * @type {string}
-     * @memberof Network
-     */
-    'address_path_prefix'?: string;
 }
 
 export const NetworkProtocolFamilyEnum = {
@@ -2004,6 +1998,7 @@ export interface ValidatorList {
  */
 
 export const ValidatorStatus = {
+    Unknown: 'unknown',
     Provisioning: 'provisioning',
     Provisioned: 'provisioned',
     Deposited: 'deposited',

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -626,7 +626,7 @@ export interface EthereumValidatorMetadata {
      * @type {string}
      * @memberof EthereumValidatorMetadata
      */
-    'withdrawal_address': string;
+    'withdrawl_address': string;
     /**
      * Whether the validator has been slashed.
      * @type {boolean}
@@ -4278,6 +4278,54 @@ export class ServerSignersApi extends BaseAPI implements ServerSignersApiInterfa
 export const StakeApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
+         * Broadcast a staking operation.
+         * @summary Broadcast a staking operation
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address the staking operation belongs to.
+         * @param {string} stakingOperationId The ID of the staking operation to broadcast.
+         * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        broadcastStakingOperation: async (walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('broadcastStakingOperation', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('broadcastStakingOperation', 'addressId', addressId)
+            // verify required parameter 'stakingOperationId' is not null or undefined
+            assertParamExists('broadcastStakingOperation', 'stakingOperationId', stakingOperationId)
+            // verify required parameter 'broadcastStakingOperationRequest' is not null or undefined
+            assertParamExists('broadcastStakingOperation', 'broadcastStakingOperationRequest', broadcastStakingOperationRequest)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/staking_operations/{staking_operation_id}/broadcast`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)))
+                .replace(`{${"staking_operation_id"}}`, encodeURIComponent(String(stakingOperationId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(broadcastStakingOperationRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Build a new staking operation
          * @summary Build a new staking operation
          * @param {BuildStakingOperationRequest} buildStakingOperationRequest 
@@ -4307,6 +4355,50 @@ export const StakeApiAxiosParamCreator = function (configuration?: Configuration
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(buildStakingOperationRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Create a new staking operation.
+         * @summary Create a new staking operation for an address
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address to create the staking operation for.
+         * @param {CreateStakingOperationRequest} createStakingOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createStakingOperation: async (walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('createStakingOperation', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('createStakingOperation', 'addressId', addressId)
+            // verify required parameter 'createStakingOperationRequest' is not null or undefined
+            assertParamExists('createStakingOperation', 'createStakingOperationRequest', createStakingOperationRequest)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/staking_operations`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(createStakingOperationRequest, localVarRequestOptions, configuration)
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4510,6 +4602,48 @@ export const StakeApiAxiosParamCreator = function (configuration?: Configuration
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * Get the latest state of a staking operation.
+         * @summary Get the latest state of a staking operation
+         * @param {string} walletId The ID of the wallet the address belongs to
+         * @param {string} addressId The ID of the address to fetch the staking operation for.
+         * @param {string} stakingOperationId The ID of the staking operation.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getStakingOperation: async (walletId: string, addressId: string, stakingOperationId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('getStakingOperation', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('getStakingOperation', 'addressId', addressId)
+            // verify required parameter 'stakingOperationId' is not null or undefined
+            assertParamExists('getStakingOperation', 'stakingOperationId', stakingOperationId)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/staking_operations/{staking_operation_id}`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)))
+                .replace(`{${"staking_operation_id"}}`, encodeURIComponent(String(stakingOperationId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -4521,6 +4655,22 @@ export const StakeApiFp = function(configuration?: Configuration) {
     const localVarAxiosParamCreator = StakeApiAxiosParamCreator(configuration)
     return {
         /**
+         * Broadcast a staking operation.
+         * @summary Broadcast a staking operation
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address the staking operation belongs to.
+         * @param {string} stakingOperationId The ID of the staking operation to broadcast.
+         * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StakingOperation>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.broadcastStakingOperation(walletId, addressId, stakingOperationId, broadcastStakingOperationRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['StakeApi.broadcastStakingOperation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * Build a new staking operation
          * @summary Build a new staking operation
          * @param {BuildStakingOperationRequest} buildStakingOperationRequest 
@@ -4531,6 +4681,21 @@ export const StakeApiFp = function(configuration?: Configuration) {
             const localVarAxiosArgs = await localVarAxiosParamCreator.buildStakingOperation(buildStakingOperationRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['StakeApi.buildStakingOperation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Create a new staking operation.
+         * @summary Create a new staking operation for an address
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address to create the staking operation for.
+         * @param {CreateStakingOperationRequest} createStakingOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StakingOperation>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createStakingOperation(walletId, addressId, createStakingOperationRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['StakeApi.createStakingOperation']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
@@ -4595,6 +4760,21 @@ export const StakeApiFp = function(configuration?: Configuration) {
             const localVarOperationServerBasePath = operationServerMap['StakeApi.getStakingContext']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
+        /**
+         * Get the latest state of a staking operation.
+         * @summary Get the latest state of a staking operation
+         * @param {string} walletId The ID of the wallet the address belongs to
+         * @param {string} addressId The ID of the address to fetch the staking operation for.
+         * @param {string} stakingOperationId The ID of the staking operation.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StakingOperation>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getStakingOperation(walletId, addressId, stakingOperationId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['StakeApi.getStakingOperation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
     }
 };
 
@@ -4606,6 +4786,19 @@ export const StakeApiFactory = function (configuration?: Configuration, basePath
     const localVarFp = StakeApiFp(configuration)
     return {
         /**
+         * Broadcast a staking operation.
+         * @summary Broadcast a staking operation
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address the staking operation belongs to.
+         * @param {string} stakingOperationId The ID of the staking operation to broadcast.
+         * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: any): AxiosPromise<StakingOperation> {
+            return localVarFp.broadcastStakingOperation(walletId, addressId, stakingOperationId, broadcastStakingOperationRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
          * Build a new staking operation
          * @summary Build a new staking operation
          * @param {BuildStakingOperationRequest} buildStakingOperationRequest 
@@ -4614,6 +4807,18 @@ export const StakeApiFactory = function (configuration?: Configuration, basePath
          */
         buildStakingOperation(buildStakingOperationRequest: BuildStakingOperationRequest, options?: any): AxiosPromise<StakingOperation> {
             return localVarFp.buildStakingOperation(buildStakingOperationRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Create a new staking operation.
+         * @summary Create a new staking operation for an address
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address to create the staking operation for.
+         * @param {CreateStakingOperationRequest} createStakingOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: any): AxiosPromise<StakingOperation> {
+            return localVarFp.createStakingOperation(walletId, addressId, createStakingOperationRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * Fetch historical staking balances for given address.
@@ -4665,6 +4870,18 @@ export const StakeApiFactory = function (configuration?: Configuration, basePath
         getStakingContext(getStakingContextRequest: GetStakingContextRequest, options?: any): AxiosPromise<StakingContext> {
             return localVarFp.getStakingContext(getStakingContextRequest, options).then((request) => request(axios, basePath));
         },
+        /**
+         * Get the latest state of a staking operation.
+         * @summary Get the latest state of a staking operation
+         * @param {string} walletId The ID of the wallet the address belongs to
+         * @param {string} addressId The ID of the address to fetch the staking operation for.
+         * @param {string} stakingOperationId The ID of the staking operation.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: any): AxiosPromise<StakingOperation> {
+            return localVarFp.getStakingOperation(walletId, addressId, stakingOperationId, options).then((request) => request(axios, basePath));
+        },
     };
 };
 
@@ -4675,6 +4892,19 @@ export const StakeApiFactory = function (configuration?: Configuration, basePath
  */
 export interface StakeApiInterface {
     /**
+     * Broadcast a staking operation.
+     * @summary Broadcast a staking operation
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address the staking operation belongs to.
+     * @param {string} stakingOperationId The ID of the staking operation to broadcast.
+     * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof StakeApiInterface
+     */
+    broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
+
+    /**
      * Build a new staking operation
      * @summary Build a new staking operation
      * @param {BuildStakingOperationRequest} buildStakingOperationRequest 
@@ -4683,6 +4913,18 @@ export interface StakeApiInterface {
      * @memberof StakeApiInterface
      */
     buildStakingOperation(buildStakingOperationRequest: BuildStakingOperationRequest, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
+
+    /**
+     * Create a new staking operation.
+     * @summary Create a new staking operation for an address
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address to create the staking operation for.
+     * @param {CreateStakingOperationRequest} createStakingOperationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof StakeApiInterface
+     */
+    createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
 
     /**
      * Fetch historical staking balances for given address.
@@ -4734,6 +4976,18 @@ export interface StakeApiInterface {
      */
     getStakingContext(getStakingContextRequest: GetStakingContextRequest, options?: RawAxiosRequestConfig): AxiosPromise<StakingContext>;
 
+    /**
+     * Get the latest state of a staking operation.
+     * @summary Get the latest state of a staking operation
+     * @param {string} walletId The ID of the wallet the address belongs to
+     * @param {string} addressId The ID of the address to fetch the staking operation for.
+     * @param {string} stakingOperationId The ID of the staking operation.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof StakeApiInterface
+     */
+    getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
+
 }
 
 /**
@@ -4744,6 +4998,21 @@ export interface StakeApiInterface {
  */
 export class StakeApi extends BaseAPI implements StakeApiInterface {
     /**
+     * Broadcast a staking operation.
+     * @summary Broadcast a staking operation
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address the staking operation belongs to.
+     * @param {string} stakingOperationId The ID of the staking operation to broadcast.
+     * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof StakeApi
+     */
+    public broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: RawAxiosRequestConfig) {
+        return StakeApiFp(this.configuration).broadcastStakingOperation(walletId, addressId, stakingOperationId, broadcastStakingOperationRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
      * Build a new staking operation
      * @summary Build a new staking operation
      * @param {BuildStakingOperationRequest} buildStakingOperationRequest 
@@ -4753,6 +5022,20 @@ export class StakeApi extends BaseAPI implements StakeApiInterface {
      */
     public buildStakingOperation(buildStakingOperationRequest: BuildStakingOperationRequest, options?: RawAxiosRequestConfig) {
         return StakeApiFp(this.configuration).buildStakingOperation(buildStakingOperationRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Create a new staking operation.
+     * @summary Create a new staking operation for an address
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address to create the staking operation for.
+     * @param {CreateStakingOperationRequest} createStakingOperationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof StakeApi
+     */
+    public createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: RawAxiosRequestConfig) {
+        return StakeApiFp(this.configuration).createStakingOperation(walletId, addressId, createStakingOperationRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -4811,6 +5094,20 @@ export class StakeApi extends BaseAPI implements StakeApiInterface {
      */
     public getStakingContext(getStakingContextRequest: GetStakingContextRequest, options?: RawAxiosRequestConfig) {
         return StakeApiFp(this.configuration).getStakingContext(getStakingContextRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Get the latest state of a staking operation.
+     * @summary Get the latest state of a staking operation
+     * @param {string} walletId The ID of the wallet the address belongs to
+     * @param {string} addressId The ID of the address to fetch the staking operation for.
+     * @param {string} stakingOperationId The ID of the staking operation.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof StakeApi
+     */
+    public getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: RawAxiosRequestConfig) {
+        return StakeApiFp(this.configuration).getStakingOperation(walletId, addressId, stakingOperationId, options).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -6083,350 +6380,6 @@ export class ValidatorsApi extends BaseAPI implements ValidatorsApiInterface {
      */
     public listValidators(networkId: string, assetId: string, status?: ValidatorStatus, limit?: number, page?: string, options?: RawAxiosRequestConfig) {
         return ValidatorsApiFp(this.configuration).listValidators(networkId, assetId, status, limit, page, options).then((request) => request(this.axios, this.basePath));
-    }
-}
-
-
-
-/**
- * WalletStakeApi - axios parameter creator
- * @export
- */
-export const WalletStakeApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * Broadcast a staking operation.
-         * @summary Broadcast a staking operation
-         * @param {string} walletId The ID of the wallet the address belongs to.
-         * @param {string} addressId The ID of the address the staking operation belongs to.
-         * @param {string} stakingOperationId The ID of the staking operation to broadcast.
-         * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        broadcastStakingOperation: async (walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'walletId' is not null or undefined
-            assertParamExists('broadcastStakingOperation', 'walletId', walletId)
-            // verify required parameter 'addressId' is not null or undefined
-            assertParamExists('broadcastStakingOperation', 'addressId', addressId)
-            // verify required parameter 'stakingOperationId' is not null or undefined
-            assertParamExists('broadcastStakingOperation', 'stakingOperationId', stakingOperationId)
-            // verify required parameter 'broadcastStakingOperationRequest' is not null or undefined
-            assertParamExists('broadcastStakingOperation', 'broadcastStakingOperationRequest', broadcastStakingOperationRequest)
-            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/staking_operations/{staking_operation_id}/broadcast`
-                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
-                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)))
-                .replace(`{${"staking_operation_id"}}`, encodeURIComponent(String(stakingOperationId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(broadcastStakingOperationRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Create a new staking operation.
-         * @summary Create a new staking operation for an address
-         * @param {string} walletId The ID of the wallet the address belongs to.
-         * @param {string} addressId The ID of the address to create the staking operation for.
-         * @param {CreateStakingOperationRequest} createStakingOperationRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createStakingOperation: async (walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'walletId' is not null or undefined
-            assertParamExists('createStakingOperation', 'walletId', walletId)
-            // verify required parameter 'addressId' is not null or undefined
-            assertParamExists('createStakingOperation', 'addressId', addressId)
-            // verify required parameter 'createStakingOperationRequest' is not null or undefined
-            assertParamExists('createStakingOperation', 'createStakingOperationRequest', createStakingOperationRequest)
-            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/staking_operations`
-                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
-                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(createStakingOperationRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Get the latest state of a staking operation.
-         * @summary Get the latest state of a staking operation
-         * @param {string} walletId The ID of the wallet the address belongs to
-         * @param {string} addressId The ID of the address to fetch the staking operation for.
-         * @param {string} stakingOperationId The ID of the staking operation.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getStakingOperation: async (walletId: string, addressId: string, stakingOperationId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'walletId' is not null or undefined
-            assertParamExists('getStakingOperation', 'walletId', walletId)
-            // verify required parameter 'addressId' is not null or undefined
-            assertParamExists('getStakingOperation', 'addressId', addressId)
-            // verify required parameter 'stakingOperationId' is not null or undefined
-            assertParamExists('getStakingOperation', 'stakingOperationId', stakingOperationId)
-            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/staking_operations/{staking_operation_id}`
-                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
-                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)))
-                .replace(`{${"staking_operation_id"}}`, encodeURIComponent(String(stakingOperationId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * WalletStakeApi - functional programming interface
- * @export
- */
-export const WalletStakeApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = WalletStakeApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * Broadcast a staking operation.
-         * @summary Broadcast a staking operation
-         * @param {string} walletId The ID of the wallet the address belongs to.
-         * @param {string} addressId The ID of the address the staking operation belongs to.
-         * @param {string} stakingOperationId The ID of the staking operation to broadcast.
-         * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StakingOperation>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.broadcastStakingOperation(walletId, addressId, stakingOperationId, broadcastStakingOperationRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['WalletStakeApi.broadcastStakingOperation']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Create a new staking operation.
-         * @summary Create a new staking operation for an address
-         * @param {string} walletId The ID of the wallet the address belongs to.
-         * @param {string} addressId The ID of the address to create the staking operation for.
-         * @param {CreateStakingOperationRequest} createStakingOperationRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StakingOperation>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createStakingOperation(walletId, addressId, createStakingOperationRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['WalletStakeApi.createStakingOperation']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Get the latest state of a staking operation.
-         * @summary Get the latest state of a staking operation
-         * @param {string} walletId The ID of the wallet the address belongs to
-         * @param {string} addressId The ID of the address to fetch the staking operation for.
-         * @param {string} stakingOperationId The ID of the staking operation.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StakingOperation>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getStakingOperation(walletId, addressId, stakingOperationId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['WalletStakeApi.getStakingOperation']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * WalletStakeApi - factory interface
- * @export
- */
-export const WalletStakeApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = WalletStakeApiFp(configuration)
-    return {
-        /**
-         * Broadcast a staking operation.
-         * @summary Broadcast a staking operation
-         * @param {string} walletId The ID of the wallet the address belongs to.
-         * @param {string} addressId The ID of the address the staking operation belongs to.
-         * @param {string} stakingOperationId The ID of the staking operation to broadcast.
-         * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: any): AxiosPromise<StakingOperation> {
-            return localVarFp.broadcastStakingOperation(walletId, addressId, stakingOperationId, broadcastStakingOperationRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Create a new staking operation.
-         * @summary Create a new staking operation for an address
-         * @param {string} walletId The ID of the wallet the address belongs to.
-         * @param {string} addressId The ID of the address to create the staking operation for.
-         * @param {CreateStakingOperationRequest} createStakingOperationRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: any): AxiosPromise<StakingOperation> {
-            return localVarFp.createStakingOperation(walletId, addressId, createStakingOperationRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Get the latest state of a staking operation.
-         * @summary Get the latest state of a staking operation
-         * @param {string} walletId The ID of the wallet the address belongs to
-         * @param {string} addressId The ID of the address to fetch the staking operation for.
-         * @param {string} stakingOperationId The ID of the staking operation.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: any): AxiosPromise<StakingOperation> {
-            return localVarFp.getStakingOperation(walletId, addressId, stakingOperationId, options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * WalletStakeApi - interface
- * @export
- * @interface WalletStakeApi
- */
-export interface WalletStakeApiInterface {
-    /**
-     * Broadcast a staking operation.
-     * @summary Broadcast a staking operation
-     * @param {string} walletId The ID of the wallet the address belongs to.
-     * @param {string} addressId The ID of the address the staking operation belongs to.
-     * @param {string} stakingOperationId The ID of the staking operation to broadcast.
-     * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WalletStakeApiInterface
-     */
-    broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
-
-    /**
-     * Create a new staking operation.
-     * @summary Create a new staking operation for an address
-     * @param {string} walletId The ID of the wallet the address belongs to.
-     * @param {string} addressId The ID of the address to create the staking operation for.
-     * @param {CreateStakingOperationRequest} createStakingOperationRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WalletStakeApiInterface
-     */
-    createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
-
-    /**
-     * Get the latest state of a staking operation.
-     * @summary Get the latest state of a staking operation
-     * @param {string} walletId The ID of the wallet the address belongs to
-     * @param {string} addressId The ID of the address to fetch the staking operation for.
-     * @param {string} stakingOperationId The ID of the staking operation.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WalletStakeApiInterface
-     */
-    getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: RawAxiosRequestConfig): AxiosPromise<StakingOperation>;
-
-}
-
-/**
- * WalletStakeApi - object-oriented interface
- * @export
- * @class WalletStakeApi
- * @extends {BaseAPI}
- */
-export class WalletStakeApi extends BaseAPI implements WalletStakeApiInterface {
-    /**
-     * Broadcast a staking operation.
-     * @summary Broadcast a staking operation
-     * @param {string} walletId The ID of the wallet the address belongs to.
-     * @param {string} addressId The ID of the address the staking operation belongs to.
-     * @param {string} stakingOperationId The ID of the staking operation to broadcast.
-     * @param {BroadcastStakingOperationRequest} broadcastStakingOperationRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WalletStakeApi
-     */
-    public broadcastStakingOperation(walletId: string, addressId: string, stakingOperationId: string, broadcastStakingOperationRequest: BroadcastStakingOperationRequest, options?: RawAxiosRequestConfig) {
-        return WalletStakeApiFp(this.configuration).broadcastStakingOperation(walletId, addressId, stakingOperationId, broadcastStakingOperationRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * Create a new staking operation.
-     * @summary Create a new staking operation for an address
-     * @param {string} walletId The ID of the wallet the address belongs to.
-     * @param {string} addressId The ID of the address to create the staking operation for.
-     * @param {CreateStakingOperationRequest} createStakingOperationRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WalletStakeApi
-     */
-    public createStakingOperation(walletId: string, addressId: string, createStakingOperationRequest: CreateStakingOperationRequest, options?: RawAxiosRequestConfig) {
-        return WalletStakeApiFp(this.configuration).createStakingOperation(walletId, addressId, createStakingOperationRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * Get the latest state of a staking operation.
-     * @summary Get the latest state of a staking operation
-     * @param {string} walletId The ID of the wallet the address belongs to
-     * @param {string} addressId The ID of the address to fetch the staking operation for.
-     * @param {string} stakingOperationId The ID of the staking operation.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WalletStakeApi
-     */
-    public getStakingOperation(walletId: string, addressId: string, stakingOperationId: string, options?: RawAxiosRequestConfig) {
-        return WalletStakeApiFp(this.configuration).getStakingOperation(walletId, addressId, stakingOperationId, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -33,7 +33,6 @@ import {
   CreateStakingOperationRequest,
   ValidatorList,
   Validator,
-  ValidatorStatus,
   Webhook as WebhookModel,
   WebhookList,
   CreateWebhookRequest,
@@ -674,6 +673,22 @@ export enum SponsoredSendStatus {
   SUBMITTED = "submitted",
   COMPLETE = "complete",
   FAILED = "failed",
+}
+
+export enum ValidatorStatus {
+  Unknown = "unknown",
+  Provisioning = "provisioning",
+  Provisioned = "provisioned",
+  Deposited = "deposited",
+  PendingActivation = "pending_activation",
+  Active = "active",
+  Exiting = "exiting",
+  Exited = "exited",
+  WithdrawalAvailable = "withdrawal_available",
+  WithdrawalComplete = "withdrawal_complete",
+  ActiveSlashed = "active_slashed",
+  ExitedSlashed = "exited_slashed",
+  Reaped = "reaped",
 }
 
 /**

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -676,6 +676,10 @@ export enum SponsoredSendStatus {
   FAILED = "failed",
 }
 
+/**
+ * Validator status type definition.
+ * Represents the various states a validator can be in.
+ */
 export enum ValidatorStatus {
   UNKNOWN = "unknown",
   PROVISIONING = "provisioning",

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -34,6 +34,10 @@ import {
   ValidatorList,
   Validator,
   ValidatorStatus,
+  Webhook as WebhookModel,
+  WebhookList,
+  CreateWebhookRequest,
+  UpdateWebhookRequest,
 } from "./../client/api";
 import { Address } from "./address";
 import { Wallet } from "./wallet";

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -33,10 +33,7 @@ import {
   CreateStakingOperationRequest,
   ValidatorList,
   Validator,
-  Webhook as WebhookModel,
-  WebhookList,
-  CreateWebhookRequest,
-  UpdateWebhookRequest,
+  ValidatorStatus,
 } from "./../client/api";
 import { Address } from "./address";
 import { Wallet } from "./wallet";
@@ -507,7 +504,7 @@ export type ValidatorAPIClient = {
   listValidators(
     networkId: string,
     assetId: string,
-    status?: string,
+    status?: ValidatorStatus,
     limit?: number,
     page?: string,
     options?: AxiosRequestConfig,

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -33,6 +33,7 @@ import {
   CreateStakingOperationRequest,
   ValidatorList,
   Validator,
+  ValidatorStatus as APIValidatorStatus,
   Webhook as WebhookModel,
   WebhookList,
   CreateWebhookRequest,
@@ -507,7 +508,7 @@ export type ValidatorAPIClient = {
   listValidators(
     networkId: string,
     assetId: string,
-    status?: ValidatorStatus,
+    status?: APIValidatorStatus,
     limit?: number,
     page?: string,
     options?: AxiosRequestConfig,
@@ -676,19 +677,19 @@ export enum SponsoredSendStatus {
 }
 
 export enum ValidatorStatus {
-  Unknown = "unknown",
-  Provisioning = "provisioning",
-  Provisioned = "provisioned",
-  Deposited = "deposited",
-  PendingActivation = "pending_activation",
-  Active = "active",
-  Exiting = "exiting",
-  Exited = "exited",
-  WithdrawalAvailable = "withdrawal_available",
-  WithdrawalComplete = "withdrawal_complete",
-  ActiveSlashed = "active_slashed",
-  ExitedSlashed = "exited_slashed",
-  Reaped = "reaped",
+  UNKNOWN = "unknown",
+  PROVISIONING = "provisioning",
+  PROVISIONED = "provisioned",
+  DEPOSITED = "deposited",
+  PENDING_ACTIVATION = "pending_activation",
+  ACTIVE = "active",
+  EXITING = "exiting",
+  EXITED = "exited",
+  WITHDRAWAL_AVAILABLE = "withdrawal_available",
+  WITHDRAWAL_COMPLETE = "withdrawal_complete",
+  ACTIVE_SLASHED = "active_slashed",
+  EXITED_SLASHED = "exited_slashed",
+  REAPED = "reaped",
 }
 
 /**

--- a/src/coinbase/validator.ts
+++ b/src/coinbase/validator.ts
@@ -1,5 +1,5 @@
 import { Coinbase } from "./coinbase";
-import { Validator as ValidatorModel } from "../client/api";
+import { Validator as ValidatorModel, ValidatorStatus } from "../client/api";
 import { InternalError } from "./errors";
 
 /**
@@ -34,7 +34,7 @@ export class Validator {
   public static async list(
     networkId: string,
     assetId: string,
-    status?: string,
+    status?: ValidatorStatus,
   ): Promise<Validator[]> {
     const validators: Validator[] = [];
 

--- a/src/coinbase/validator.ts
+++ b/src/coinbase/validator.ts
@@ -41,7 +41,7 @@ export class Validator {
     const response = await Coinbase.apiClients.validator!.listValidators(
       networkId,
       assetId,
-      status,
+      Validator.getAPIValidatorStatus(status),
     );
 
     response.data.data.forEach(validator => {
@@ -65,6 +65,45 @@ export class Validator {
 
     return new Validator(response.data);
   }
+  /**
+   * Returns the Validator status.
+   *
+   * @param status - The API Validator status.
+   * @returns The Validator status.
+   */
+  private static getAPIValidatorStatus(status?: ValidatorStatus): APIValidatorStatus {
+    /* istanbul ignore next */
+    switch (status) {
+      case ValidatorStatus.UNKNOWN:
+        return APIValidatorStatus.Unknown;
+      case ValidatorStatus.PROVISIONING:
+        return APIValidatorStatus.Provisioning;
+      case ValidatorStatus.PROVISIONED:
+        return APIValidatorStatus.Provisioned;
+      case ValidatorStatus.DEPOSITED:
+        return APIValidatorStatus.Deposited;
+      case ValidatorStatus.PENDING_ACTIVATION:
+        return APIValidatorStatus.PendingActivation;
+      case ValidatorStatus.ACTIVE:
+        return APIValidatorStatus.Active;
+      case ValidatorStatus.EXITING:
+        return APIValidatorStatus.Exiting;
+      case ValidatorStatus.EXITED:
+        return APIValidatorStatus.Exited;
+      case ValidatorStatus.WITHDRAWAL_AVAILABLE:
+        return APIValidatorStatus.WithdrawalAvailable;
+      case ValidatorStatus.WITHDRAWAL_COMPLETE:
+        return APIValidatorStatus.WithdrawalComplete;
+      case ValidatorStatus.ACTIVE_SLASHED:
+        return APIValidatorStatus.ActiveSlashed;
+      case ValidatorStatus.EXITED_SLASHED:
+        return APIValidatorStatus.ExitedSlashed;
+      case ValidatorStatus.REAPED:
+        return APIValidatorStatus.Reaped;
+      default:
+        return APIValidatorStatus.Unknown;
+    }
+  }
 
   /**
    * Returns the Validator ID.
@@ -82,37 +121,36 @@ export class Validator {
    */
   public getStatus(): string {
     switch (this.model.status) {
-      case ValidatorStatus.Unknown:
-        return APIValidatorStatus.Unknown;
-      case ValidatorStatus.Provisioning:
-        return APIValidatorStatus.Provisioning;
-      case ValidatorStatus.Provisioned:
-        return APIValidatorStatus.Provisioned;
-      case ValidatorStatus.Deposited:
-        return APIValidatorStatus.Deposited;
-      case ValidatorStatus.PendingActivation:
-        return APIValidatorStatus.PendingActivation;
-      case ValidatorStatus.Active:
-        return APIValidatorStatus.Active;
-      case ValidatorStatus.Exiting:
-        return APIValidatorStatus.Exiting;
-      case ValidatorStatus.Exited:
-        return APIValidatorStatus.Exited;
-      case ValidatorStatus.WithdrawalAvailable:
-        return APIValidatorStatus.WithdrawalAvailable;
-      case ValidatorStatus.WithdrawalComplete:
-        return APIValidatorStatus.WithdrawalComplete;
-      case ValidatorStatus.ActiveSlashed:
-        return APIValidatorStatus.ActiveSlashed;
-      case ValidatorStatus.ExitedSlashed:
-        return APIValidatorStatus.ExitedSlashed;
-      case ValidatorStatus.Reaped:
-        return APIValidatorStatus.Reaped;
+      case APIValidatorStatus.Unknown:
+        return ValidatorStatus.UNKNOWN;
+      case APIValidatorStatus.Provisioning:
+        return ValidatorStatus.PROVISIONING;
+      case APIValidatorStatus.Provisioned:
+        return ValidatorStatus.PROVISIONED;
+      case APIValidatorStatus.Deposited:
+        return ValidatorStatus.DEPOSITED;
+      case APIValidatorStatus.PendingActivation:
+        return ValidatorStatus.PENDING_ACTIVATION;
+      case APIValidatorStatus.Active:
+        return ValidatorStatus.ACTIVE;
+      case APIValidatorStatus.Exiting:
+        return ValidatorStatus.EXITING;
+      case APIValidatorStatus.Exited:
+        return ValidatorStatus.EXITED;
+      case APIValidatorStatus.WithdrawalAvailable:
+        return ValidatorStatus.WITHDRAWAL_AVAILABLE;
+      case APIValidatorStatus.WithdrawalComplete:
+        return ValidatorStatus.WITHDRAWAL_COMPLETE;
+      case APIValidatorStatus.ActiveSlashed:
+        return ValidatorStatus.ACTIVE_SLASHED;
+      case APIValidatorStatus.ExitedSlashed:
+        return ValidatorStatus.EXITED_SLASHED;
+      case APIValidatorStatus.Reaped:
+        return ValidatorStatus.REAPED;
       default:
-        return APIValidatorStatus.Unknown;
+        return ValidatorStatus.UNKNOWN;
     }
   }
-
   /**
    * Returns the string representation of the Validator.
    *

--- a/src/coinbase/validator.ts
+++ b/src/coinbase/validator.ts
@@ -1,5 +1,6 @@
 import { Coinbase } from "./coinbase";
-import { Validator as ValidatorModel, ValidatorStatus } from "../client/api";
+import { Validator as ValidatorModel, ValidatorStatus as APIValidatorStatus } from "../client/api";
+import { ValidatorStatus } from "./types";
 import { InternalError } from "./errors";
 
 /**
@@ -37,7 +38,6 @@ export class Validator {
     status?: ValidatorStatus,
   ): Promise<Validator[]> {
     const validators: Validator[] = [];
-
     const response = await Coinbase.apiClients.validator!.listValidators(
       networkId,
       assetId,
@@ -81,7 +81,36 @@ export class Validator {
    * @returns The Validator status.
    */
   public getStatus(): string {
-    return this.model.status;
+    switch (this.model.status) {
+      case ValidatorStatus.Unknown:
+        return APIValidatorStatus.Unknown;
+      case ValidatorStatus.Provisioning:
+        return APIValidatorStatus.Provisioning;
+      case ValidatorStatus.Provisioned:
+        return APIValidatorStatus.Provisioned;
+      case ValidatorStatus.Deposited:
+        return APIValidatorStatus.Deposited;
+      case ValidatorStatus.PendingActivation:
+        return APIValidatorStatus.PendingActivation;
+      case ValidatorStatus.Active:
+        return APIValidatorStatus.Active;
+      case ValidatorStatus.Exiting:
+        return APIValidatorStatus.Exiting;
+      case ValidatorStatus.Exited:
+        return APIValidatorStatus.Exited;
+      case ValidatorStatus.WithdrawalAvailable:
+        return APIValidatorStatus.WithdrawalAvailable;
+      case ValidatorStatus.WithdrawalComplete:
+        return APIValidatorStatus.WithdrawalComplete;
+      case ValidatorStatus.ActiveSlashed:
+        return APIValidatorStatus.ActiveSlashed;
+      case ValidatorStatus.ExitedSlashed:
+        return APIValidatorStatus.ExitedSlashed;
+      case ValidatorStatus.Reaped:
+        return APIValidatorStatus.Reaped;
+      default:
+        return APIValidatorStatus.Unknown;
+    }
   }
 
   /**

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -15,6 +15,7 @@ import {
   Validator,
   StakingOperationStatusEnum,
   FeatureSet,
+  ValidatorStatus,
 } from "../client";
 import { BASE_PATH } from "../client/base";
 import { Coinbase } from "../coinbase/coinbase";
@@ -297,7 +298,7 @@ export const VALID_ADDRESS_BALANCE_LIST: AddressBalanceList = {
  */
 export function mockEthereumValidator(
   index: string,
-  status: string,
+  status: ValidatorStatus,
   public_key: string,
 ): Validator {
   return {
@@ -333,9 +334,9 @@ export function mockEthereumValidator(
 
 export const VALID_ACTIVE_VALIDATOR_LIST: ValidatorList = {
   data: [
-    mockEthereumValidator("100", "active_ongoing", "0xpublic_key_1"),
-    mockEthereumValidator("200", "active_ongoing", "0xpublic_key_2"),
-    mockEthereumValidator("300", "active_ongoing", "0xpublic_key_3"),
+    mockEthereumValidator("100", ValidatorStatus.Active, "0xpublic_key_1"),
+    mockEthereumValidator("200", ValidatorStatus.Active, "0xpublic_key_2"),
+    mockEthereumValidator("300", ValidatorStatus.Active, "0xpublic_key_3"),
   ],
   has_more: false,
   next_page: "",
@@ -343,9 +344,9 @@ export const VALID_ACTIVE_VALIDATOR_LIST: ValidatorList = {
 
 export const VALID_EXITING_VALIDATOR_LIST: ValidatorList = {
   data: [
-    mockEthereumValidator("400", "active_exiting", "0xpublic_key_4"),
-    mockEthereumValidator("500", "active_exiting", "0xpublic_key_5"),
-    mockEthereumValidator("600", "active_exiting", "0xpublic_key_6"),
+    mockEthereumValidator("400", ValidatorStatus.Exiting, "0xpublic_key_4"),
+    mockEthereumValidator("500", ValidatorStatus.Exiting, "0xpublic_key_5"),
+    mockEthereumValidator("600", ValidatorStatus.Exiting, "0xpublic_key_6"),
   ],
   has_more: false,
   next_page: "",

--- a/src/tests/validator_test.ts
+++ b/src/tests/validator_test.ts
@@ -31,7 +31,7 @@ describe("Validator", () => {
     });
   });
 
-  describe("getStatus", () => {
+  describe(".getStatus", () => {
     const testCases = [
       { input: APIValidatorStatus.Unknown, expected: ValidatorStatus.UNKNOWN },
       { input: APIValidatorStatus.Provisioning, expected: ValidatorStatus.PROVISIONING },
@@ -64,7 +64,7 @@ describe("Validator", () => {
     });
   });
 
-  describe("getAPIValidatorStatus", () => {
+  describe("#getAPIValidatorStatus", () => {
     const testCases = [
       { input: ValidatorStatus.UNKNOWN, expected: APIValidatorStatus.Unknown },
       { input: ValidatorStatus.PROVISIONING, expected: APIValidatorStatus.Provisioning },

--- a/src/tests/validator_test.ts
+++ b/src/tests/validator_test.ts
@@ -20,7 +20,7 @@ describe("Validator", () => {
   });
 
   describe("constructor", () => {
-    const validatorModel = mockEthereumValidator("100", ValidatorStatus.Active, "0xpublic_key_1");
+    const validatorModel = mockEthereumValidator("100", ValidatorStatus.ACTIVE, "0xpublic_key_1");
     const validator = new Validator(validatorModel);
     it("initializes a new Validator", () => {
       expect(validator).toBeInstanceOf(Validator);
@@ -33,25 +33,58 @@ describe("Validator", () => {
 
   describe("getStatus", () => {
     const testCases = [
-      { input: ValidatorStatus.Unknown, expected: APIValidatorStatus.Unknown },
-      { input: ValidatorStatus.Provisioning, expected: APIValidatorStatus.Provisioning },
-      { input: ValidatorStatus.Provisioned, expected: APIValidatorStatus.Provisioned },
-      { input: ValidatorStatus.Deposited, expected: APIValidatorStatus.Deposited },
-      { input: ValidatorStatus.PendingActivation, expected: APIValidatorStatus.PendingActivation },
-      { input: ValidatorStatus.Active, expected: APIValidatorStatus.Active },
-      { input: ValidatorStatus.Exiting, expected: APIValidatorStatus.Exiting },
-      { input: ValidatorStatus.Exited, expected: APIValidatorStatus.Exited },
+      { input: APIValidatorStatus.Unknown, expected: ValidatorStatus.UNKNOWN },
+      { input: APIValidatorStatus.Provisioning, expected: ValidatorStatus.PROVISIONING },
+      { input: APIValidatorStatus.Provisioned, expected: ValidatorStatus.PROVISIONED },
+      { input: APIValidatorStatus.Deposited, expected: ValidatorStatus.DEPOSITED },
+      { input: APIValidatorStatus.PendingActivation, expected: ValidatorStatus.PENDING_ACTIVATION },
+      { input: APIValidatorStatus.Active, expected: ValidatorStatus.ACTIVE },
+      { input: APIValidatorStatus.Exiting, expected: ValidatorStatus.EXITING },
+      { input: APIValidatorStatus.Exited, expected: ValidatorStatus.EXITED },
       {
-        input: ValidatorStatus.WithdrawalAvailable,
+        input: APIValidatorStatus.WithdrawalAvailable,
+        expected: ValidatorStatus.WITHDRAWAL_AVAILABLE,
+      },
+      {
+        input: APIValidatorStatus.WithdrawalComplete,
+        expected: ValidatorStatus.WITHDRAWAL_COMPLETE,
+      },
+      { input: APIValidatorStatus.ActiveSlashed, expected: ValidatorStatus.ACTIVE_SLASHED },
+      { input: APIValidatorStatus.ExitedSlashed, expected: ValidatorStatus.EXITED_SLASHED },
+      { input: APIValidatorStatus.Reaped, expected: ValidatorStatus.REAPED },
+      { input: "unknown_status" as APIValidatorStatus, expected: ValidatorStatus.UNKNOWN },
+    ];
+
+    testCases.forEach(({ input, expected }) => {
+      it(`should return ${expected} for ${input}`, () => {
+        const validatorModel = mockEthereumValidator("100", input, "0xpublic_key_1");
+        const validator = new Validator(validatorModel);
+        expect(validator.getStatus()).toBe(expected);
+      });
+    });
+  });
+
+  describe("getAPIValidatorStatus", () => {
+    const testCases = [
+      { input: ValidatorStatus.UNKNOWN, expected: APIValidatorStatus.Unknown },
+      { input: ValidatorStatus.PROVISIONING, expected: APIValidatorStatus.Provisioning },
+      { input: ValidatorStatus.PROVISIONED, expected: APIValidatorStatus.Provisioned },
+      { input: ValidatorStatus.DEPOSITED, expected: APIValidatorStatus.Deposited },
+      { input: ValidatorStatus.PENDING_ACTIVATION, expected: APIValidatorStatus.PendingActivation },
+      { input: ValidatorStatus.ACTIVE, expected: APIValidatorStatus.Active },
+      { input: ValidatorStatus.EXITING, expected: APIValidatorStatus.Exiting },
+      { input: ValidatorStatus.EXITED, expected: APIValidatorStatus.Exited },
+      {
+        input: ValidatorStatus.WITHDRAWAL_AVAILABLE,
         expected: APIValidatorStatus.WithdrawalAvailable,
       },
       {
-        input: ValidatorStatus.WithdrawalComplete,
+        input: ValidatorStatus.WITHDRAWAL_COMPLETE,
         expected: APIValidatorStatus.WithdrawalComplete,
       },
-      { input: ValidatorStatus.ActiveSlashed, expected: APIValidatorStatus.ActiveSlashed },
-      { input: ValidatorStatus.ExitedSlashed, expected: APIValidatorStatus.ExitedSlashed },
-      { input: ValidatorStatus.Reaped, expected: APIValidatorStatus.Reaped },
+      { input: ValidatorStatus.ACTIVE_SLASHED, expected: APIValidatorStatus.ActiveSlashed },
+      { input: ValidatorStatus.EXITED_SLASHED, expected: APIValidatorStatus.ExitedSlashed },
+      { input: ValidatorStatus.REAPED, expected: APIValidatorStatus.Reaped },
       { input: "unknown_status" as ValidatorStatus, expected: APIValidatorStatus.Unknown },
     ];
 
@@ -70,27 +103,27 @@ describe("Validator", () => {
     const validators = await Validator.list(
       Coinbase.networks.EthereumHolesky,
       Coinbase.assets.Eth,
-      ValidatorStatus.Active,
+      ValidatorStatus.ACTIVE,
     );
 
     expect(Coinbase.apiClients.validator!.listValidators).toHaveBeenCalledWith(
       Coinbase.networks.EthereumHolesky,
       Coinbase.assets.Eth,
-      ValidatorStatus.Active,
+      ValidatorStatus.ACTIVE,
     );
 
     expect(validators.length).toEqual(3);
     expect(validators[0].getValidatorId()).toEqual("0xpublic_key_1");
-    expect(validators[0].getStatus()).toEqual(ValidatorStatus.Active);
+    expect(validators[0].getStatus()).toEqual(ValidatorStatus.ACTIVE);
     expect(validators[1].getValidatorId()).toEqual("0xpublic_key_2");
-    expect(validators[1].getStatus()).toEqual(ValidatorStatus.Active);
+    expect(validators[1].getStatus()).toEqual(ValidatorStatus.ACTIVE);
     expect(validators[2].getValidatorId()).toEqual("0xpublic_key_3");
-    expect(validators[2].getStatus()).toEqual(ValidatorStatus.Active);
+    expect(validators[2].getStatus()).toEqual(ValidatorStatus.ACTIVE);
   });
 
   it("should return a validator for ethereum holesky and eth asset", async () => {
     Coinbase.apiClients.validator!.getValidator = mockReturnValue(
-      mockEthereumValidator("100", ValidatorStatus.Exiting, "0x123"),
+      mockEthereumValidator("100", ValidatorStatus.EXITING, "0x123"),
     );
 
     const validator = await Validator.fetch(
@@ -106,7 +139,7 @@ describe("Validator", () => {
     );
 
     expect(validator.getValidatorId()).toEqual("0x123");
-    expect(validator.getStatus()).toEqual(ValidatorStatus.Exiting);
+    expect(validator.getStatus()).toEqual(ValidatorStatus.EXITING);
     expect(validator.toString()).toEqual("Id: 0x123, Status: exiting");
   });
 });

--- a/src/tests/validator_test.ts
+++ b/src/tests/validator_test.ts
@@ -6,7 +6,8 @@ import {
   VALID_ACTIVE_VALIDATOR_LIST,
   validatorApiMock,
 } from "./utils";
-import { ValidatorStatus } from "../client";
+import { ValidatorStatus } from "../coinbase/types";
+import { ValidatorStatus as APIValidatorStatus } from "../client/api";
 
 describe("Validator", () => {
   beforeAll(() => {
@@ -27,6 +28,39 @@ describe("Validator", () => {
 
     it("should raise an error when initialized with a model of a different type", () => {
       expect(() => new Validator(null!)).toThrow("Invalid model type");
+    });
+  });
+
+  describe("getStatus", () => {
+    const testCases = [
+      { input: ValidatorStatus.Unknown, expected: APIValidatorStatus.Unknown },
+      { input: ValidatorStatus.Provisioning, expected: APIValidatorStatus.Provisioning },
+      { input: ValidatorStatus.Provisioned, expected: APIValidatorStatus.Provisioned },
+      { input: ValidatorStatus.Deposited, expected: APIValidatorStatus.Deposited },
+      { input: ValidatorStatus.PendingActivation, expected: APIValidatorStatus.PendingActivation },
+      { input: ValidatorStatus.Active, expected: APIValidatorStatus.Active },
+      { input: ValidatorStatus.Exiting, expected: APIValidatorStatus.Exiting },
+      { input: ValidatorStatus.Exited, expected: APIValidatorStatus.Exited },
+      {
+        input: ValidatorStatus.WithdrawalAvailable,
+        expected: APIValidatorStatus.WithdrawalAvailable,
+      },
+      {
+        input: ValidatorStatus.WithdrawalComplete,
+        expected: APIValidatorStatus.WithdrawalComplete,
+      },
+      { input: ValidatorStatus.ActiveSlashed, expected: APIValidatorStatus.ActiveSlashed },
+      { input: ValidatorStatus.ExitedSlashed, expected: APIValidatorStatus.ExitedSlashed },
+      { input: ValidatorStatus.Reaped, expected: APIValidatorStatus.Reaped },
+      { input: "unknown_status" as ValidatorStatus, expected: APIValidatorStatus.Unknown },
+    ];
+
+    testCases.forEach(({ input, expected }) => {
+      it(`should return ${expected} for ${input}`, () => {
+        const validatorModel = mockEthereumValidator("100", input, "0xpublic_key_1");
+        const validator = new Validator(validatorModel);
+        expect(validator.getStatus()).toBe(expected);
+      });
     });
   });
 

--- a/src/tests/validator_test.ts
+++ b/src/tests/validator_test.ts
@@ -6,6 +6,7 @@ import {
   VALID_ACTIVE_VALIDATOR_LIST,
   validatorApiMock,
 } from "./utils";
+import { ValidatorStatus } from "../client";
 
 describe("Validator", () => {
   beforeAll(() => {
@@ -18,7 +19,7 @@ describe("Validator", () => {
   });
 
   describe("constructor", () => {
-    const validatorModel = mockEthereumValidator("100", "active_ongoing", "0xpublic_key_1");
+    const validatorModel = mockEthereumValidator("100", ValidatorStatus.Active, "0xpublic_key_1");
     const validator = new Validator(validatorModel);
     it("initializes a new Validator", () => {
       expect(validator).toBeInstanceOf(Validator);
@@ -35,27 +36,27 @@ describe("Validator", () => {
     const validators = await Validator.list(
       Coinbase.networks.EthereumHolesky,
       Coinbase.assets.Eth,
-      "active_ongoing",
+      ValidatorStatus.Active,
     );
 
     expect(Coinbase.apiClients.validator!.listValidators).toHaveBeenCalledWith(
       Coinbase.networks.EthereumHolesky,
       Coinbase.assets.Eth,
-      "active_ongoing",
+      ValidatorStatus.Active,
     );
 
     expect(validators.length).toEqual(3);
     expect(validators[0].getValidatorId()).toEqual("0xpublic_key_1");
-    expect(validators[0].getStatus()).toEqual("active_ongoing");
+    expect(validators[0].getStatus()).toEqual(ValidatorStatus.Active);
     expect(validators[1].getValidatorId()).toEqual("0xpublic_key_2");
-    expect(validators[1].getStatus()).toEqual("active_ongoing");
+    expect(validators[1].getStatus()).toEqual(ValidatorStatus.Active);
     expect(validators[2].getValidatorId()).toEqual("0xpublic_key_3");
-    expect(validators[2].getStatus()).toEqual("active_ongoing");
+    expect(validators[2].getStatus()).toEqual(ValidatorStatus.Active);
   });
 
   it("should return a validator for ethereum holesky and eth asset", async () => {
     Coinbase.apiClients.validator!.getValidator = mockReturnValue(
-      mockEthereumValidator("100", "active_exiting", "0x123"),
+      mockEthereumValidator("100", ValidatorStatus.Exiting, "0x123"),
     );
 
     const validator = await Validator.fetch(
@@ -71,7 +72,7 @@ describe("Validator", () => {
     );
 
     expect(validator.getValidatorId()).toEqual("0x123");
-    expect(validator.getStatus()).toEqual("active_exiting");
+    expect(validator.getStatus()).toEqual(ValidatorStatus.Exiting);
     expect(validator.toString()).toEqual("Id: 0x123, Status: active_exiting");
   });
 });

--- a/src/tests/validator_test.ts
+++ b/src/tests/validator_test.ts
@@ -73,6 +73,6 @@ describe("Validator", () => {
 
     expect(validator.getValidatorId()).toEqual("0x123");
     expect(validator.getStatus()).toEqual(ValidatorStatus.Exiting);
-    expect(validator.toString()).toEqual("Id: 0x123, Status: active_exiting");
+    expect(validator.toString()).toEqual("Id: 0x123, Status: exiting");
   });
 });

--- a/src/tests/validator_test.ts
+++ b/src/tests/validator_test.ts
@@ -140,6 +140,6 @@ describe("Validator", () => {
 
     expect(validator.getValidatorId()).toEqual("0x123");
     expect(validator.getStatus()).toEqual(ValidatorStatus.EXITING);
-    expect(validator.toString()).toEqual("Id: 0x123, Status: exiting");
+    expect(validator.toString()).toEqual("Id: 0x123 Status: exiting");
   });
 });


### PR DESCRIPTION
### What changed? Why?

- Validator status is an enum instead of a hardcoded string
- Changed tests throughout 

**UX Improvement**

- The addition of the `enum` enables IDEs to automatically recommend valid statuses, improving developer experience 


<img width="575" alt="image" src="https://github.com/user-attachments/assets/3c45dacb-5230-41ed-b314-3e81796f38ea">

- In addition to supplying a string, you can also supply a `ValidatorStatus`, like so

<img width="377" alt="image" src="https://github.com/user-attachments/assets/3a2a088e-9505-419f-b376-73ee4a94e9f1">

**Testing notes**

```
> validators = await Validator.list("ethereum-holesky", "eth", ValidatorStatus.PROVISIONED);
[
  Validator {
    model: {
      asset_id: 'eth',
      details: [Object],
      network_id: 'ethereum-holesky',
      status: 'provisioned',
      validator_id: '0x84e9cf81f57d5d7956fd1daf797dc4765c28797829b951f7ce4caa76ce68030023d26ef39277ebb20d2efac44a89d009'
    }
  },
  Validator {
    model: {
      asset_id: 'eth',
      details: [Object],
      network_id: 'ethereum-holesky',
      status: 'provisioned',
      validator_id: '0x90206707fbc5a4d21db711613e9c6c903dbb37ef6707e6037321a297ae83eb9656adf3ba7d5953cc7a72df148421cec2'
    }
  }
]
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
