### PR TITLE
Support dynamic network constants

### DIFF
--- a/src/coinbase/coinbase.ts
+++ b/src/coinbase/coinbase.ts
@@ -14,6 +14,7 @@ import {
   AssetsApiFactory,
   ExternalAddressesApiFactory,
   WebhooksApiFactory,
+  NetworkIdentifier,
 } from "../client";
 import { BASE_PATH } from "./../client/base";
 import { Configuration } from "./../client/configuration";
@@ -29,16 +30,16 @@ import * as os from "os";
  */
 export class Coinbase {
   /**
-   * The list of supported networks.
+   * The map of supported networks to network ID. Generated from the OpenAPI spec.
    *
    * @constant
+   *
+   * @example
+   * ```typescript
+   * Coinbase.networks.BaseMainnet
+   * ```
    */
-  static networks = {
-    BaseSepolia: "base-sepolia",
-    BaseMainnet: "base-mainnet",
-    EthereumMainnet: "ethereum-mainnet",
-    EthereumHolesky: "ethereum-holesky",
-  };
+  static networks = NetworkIdentifier;
 
   /**
    * The list of supported assets.

--- a/src/coinbase/constants.ts
+++ b/src/coinbase/constants.ts
@@ -1,5 +1,1 @@
-import { Decimal } from "decimal.js";
-
 export const GWEI_DECIMALS = 9;
-export const WEI_PER_ETHER = new Decimal("1000000000000000000");
-export const ATOMIC_UNITS_PER_USDC = new Decimal("1000000");

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -927,8 +927,11 @@ export class Wallet {
       throw new InternalError("Cannot derive key for Wallet without seed loaded");
     }
     const [networkPrefix] = this.model.network_id.split("-");
-    // TODO: Push this logic to the backend.
-    if (!["base", "ethereum"].includes(networkPrefix)) {
+    /**
+     * TODO: Push this logic to the backend.
+     * TODO: Add unit tests for `#createAddress`.
+     */
+    if (!["base", "ethereum", "polygon"].includes(networkPrefix)) {
       throw new InternalError(`Unsupported network ID: ${this.model.network_id}`);
     }
     const derivedKey = this.master?.derive(this.addressPathPrefix + `/${index}`);

--- a/src/tests/coinbase_test.ts
+++ b/src/tests/coinbase_test.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import { randomUUID } from "crypto";
 import { APIError } from "../coinbase/api_error";
 import { Coinbase } from "../index";
+import { NetworkIdentifier } from "../client";
 import {
   VALID_WALLET_MODEL,
   addressesApiMock,
@@ -20,6 +21,16 @@ import axios from "axios";
 const PATH_PREFIX = "./src/tests/config";
 
 describe("Coinbase tests", () => {
+  describe('.networks', () => {
+    it('returns a map of networks that match the api generated NetworkIdentifier', () => {
+      expect(Coinbase.networks).toEqual(NetworkIdentifier);
+    });
+
+    it('returns the network ID when selecting a specific network', () => {
+      expect(Coinbase.networks.BaseSepolia).toEqual('base-sepolia');
+    });
+  });
+
   it("should throw an error if the API key name or private key is empty", () => {
     expect(() => new Coinbase({ apiKeyName: "", privateKey: "test" })).toThrow(
       "Invalid configuration: apiKeyName is empty",

--- a/src/tests/trade_test.ts
+++ b/src/tests/trade_test.ts
@@ -3,7 +3,6 @@ import { ethers } from "ethers";
 import { Transaction as CoinbaseTransaction, Trade as TradeModel } from "../client/api";
 import { Transaction } from "../coinbase/transaction";
 import { Coinbase } from "./../coinbase/coinbase";
-import { ATOMIC_UNITS_PER_USDC, WEI_PER_ETHER } from "./../coinbase/constants";
 import { Trade } from "./../coinbase/trade";
 import { TransactionStatus } from "./../coinbase/types";
 import { mockReturnValue } from "./utils";
@@ -35,8 +34,10 @@ describe("Trade", () => {
     addressId = fromKey.address;
     fromAmount = new Decimal(100);
     toAmount = new Decimal(100000);
-    ethAmount = fromAmount.div(new Decimal(WEI_PER_ETHER));
-    usdcAmount = toAmount.div(new Decimal(ATOMIC_UNITS_PER_USDC));
+    ethAsset = { network_id: networkId, asset_id: "eth", decimals: 18 };
+    usdcAsset = { network_id: networkId, asset_id: "usdc", decimals: 6 };
+    ethAmount = fromAmount.div(new Decimal(Math.pow(10, ethAsset.decimals)));
+    usdcAmount = toAmount.div(new Decimal(Math.pow(10, usdcAsset.decimals)));
     tradeId = ethers.Wallet.createRandom().address;
     unsignedPayload =
       "7b2274797065223a22307832222c22636861696e4964223a2230783134613334222c226e6f6e63" +
@@ -49,8 +50,6 @@ describe("Trade", () => {
       "2c2273223a22307830222c2279506172697479223a22307830222c2268617368223a2230783664" +
       "633334306534643663323633653363396561396135656438646561346332383966613861363966" +
       "3031653635393462333732386230386138323335333433227d";
-    ethAsset = { network_id: networkId, asset_id: "eth", decimals: 18 };
-    usdcAsset = { network_id: networkId, asset_id: "usdc", decimals: 6 };
     transactionModel = {
       status: "pending",
       from_address_id: addressId,
@@ -194,14 +193,14 @@ describe("Trade", () => {
       await trade.reload();
       expect(trade.getTransaction().getStatus()).toBe(TransactionStatus.COMPLETE);
       expect(trade.getToAmount()).toEqual(
-        new Decimal(500000000).div(new Decimal(ATOMIC_UNITS_PER_USDC)),
+        new Decimal(500000000).div(new Decimal(Math.pow(10, usdcAsset.decimals)))
       );
     });
     it("should update properties on the trade", async () => {
       expect(trade.getToAmount()).toEqual(usdcAmount);
       await trade.reload();
       expect(trade.getToAmount()).toEqual(
-        new Decimal(updatedModel.to_amount).div(new Decimal(ATOMIC_UNITS_PER_USDC)),
+        new Decimal(updatedModel.to_amount).div(new Decimal(Math.pow(10, usdcAsset.decimals)))
       );
     });
   });

--- a/src/tests/transfer_test.ts
+++ b/src/tests/transfer_test.ts
@@ -10,7 +10,6 @@ import { Transfer } from "../coinbase/transfer";
 import { SponsoredSend } from "../coinbase/sponsored_send";
 import { Transaction } from "../coinbase/transaction";
 import { Coinbase } from "../coinbase/coinbase";
-import { WEI_PER_ETHER } from "../coinbase/constants";
 import {
   VALID_TRANSFER_MODEL,
   VALID_TRANSFER_SPONSORED_SEND_MODEL,
@@ -21,7 +20,7 @@ import {
 import { APIError } from "../coinbase/api_error";
 
 const amount = new Decimal(ethers.parseUnits("100", 18).toString());
-const ethAmount = amount.div(WEI_PER_ETHER);
+const ethAmount = amount.div(Math.pow(10, 18));
 const signedPayload =
   "02f86b83014a3401830f4240830f4350825208946cd01c0f55ce9e0bf78f5e90f72b4345b" +
   "16d515d0280c001a0566afb8ab09129b3f5b666c3a1e4a7e92ae12bbee8c75b4c6e0c46f6" +

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -658,7 +658,8 @@ describe("Wallet Class", () => {
 
     describe("#getNetworkId", () => {
       let wallet;
-      let network_id = Coinbase.networks.BaseMainnet;
+      let network_id;
+      let createWalletParams;
 
       beforeEach(async () => {
         Coinbase.apiClients.wallet = walletsApiMock;
@@ -674,27 +675,27 @@ describe("Wallet Class", () => {
           server_signer_status: ServerSignerStatus.ACTIVE,
         });
         Coinbase.apiClients.address!.createAddress = mockReturnValue(newAddressModel(walletId));
-        const createWalletParams =
-          network_id === Coinbase.networks.BaseMainnet
-            ? {
-                networkId: network_id,
-              }
-            : undefined;
+
         wallet = await Wallet.create(createWalletParams);
       });
 
       describe("when a network is specified", () => {
         beforeAll(() => {
           network_id = Coinbase.networks.BaseMainnet;
+          createWalletParams = { networkId: network_id };
         });
+
         it("it creates a wallet scoped to the specified network", () => {
           expect(wallet.getNetworkId()).toBe(Coinbase.networks.BaseMainnet);
         });
       });
+
       describe("when no network is specified", () => {
         beforeAll(() => {
           network_id = Coinbase.networks.BaseSepolia;
+          createWalletParams = {};
         });
+
         it("it creates a wallet scoped to the default network", () => {
           expect(wallet.getNetworkId()).toBe(Coinbase.networks.BaseSepolia);
         });


### PR DESCRIPTION
### What changed? Why?
This makes it so that we dynamically update networks as we update our OpenAPI spec.

This does not add a whole network object like we have in ruby, because we probably want to play around with how people want to use the various objects in TS before doing that.

This also unblocks `polygon-mainnet` support using this SDK.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
