### PR TITLE
Add correlation context to request headers

### DIFF
--- a/src/coinbase/authenticator.ts
+++ b/src/coinbase/authenticator.ts
@@ -1,6 +1,7 @@
 import { InternalAxiosRequestConfig } from "axios";
 import { JWK, JWS } from "node-jose";
 import { InvalidAPIKeyFormat } from "./errors";
+import { version } from "../../package.json";
 
 const pemHeader = "-----BEGIN EC PRIVATE KEY-----";
 const pemFooter = "-----END EC PRIVATE KEY-----";
@@ -42,6 +43,7 @@ export class CoinbaseAuthenticator {
     }
     config.headers["Authorization"] = `Bearer ${token}`;
     config.headers["Content-Type"] = "application/json";
+    config.headers["Correlation-Context"] = this.getCorrelationData();
     return config;
   }
 
@@ -127,5 +129,21 @@ export class CoinbaseAuthenticator {
     }
 
     return result;
+  }
+
+  /**
+   * Returns encoded correlation data including the SDK version and language.
+   *
+   * @returns {string} Encoded correlation data.
+   */
+  private getCorrelationData(): string {
+    const data = {
+      sdk_version: version,
+      sdk_language: "typescript",
+    };
+
+    return Object.keys(data)
+      .map(key => `${key}=${encodeURIComponent(data[key])}`)
+      .join(",");
   }
 }

--- a/src/tests/authenticator_test.ts
+++ b/src/tests/authenticator_test.ts
@@ -44,6 +44,12 @@ describe("Authenticator tests", () => {
     expect(token?.length).toBeGreaterThan(100);
   });
 
+  it("includes a correlation context header", async () => {
+    const config = await authenticator.authenticateRequest(VALID_CONFIG, true);
+    const correlationContext = config.headers["Correlation-Context"] as string;
+    expect(correlationContext).toContain(",sdk_language=typescript");
+  });
+
   it("invalid pem key should raise an InvalidAPIKeyFormat error", async () => {
     const invalidAuthenticator = new CoinbaseAuthenticator("test-key", "-----BEGIN EC KEY-----\n");
     expect(invalidAuthenticator.authenticateRequest(VALID_CONFIG)).rejects.toThrow();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
     "skipLibCheck": true,


### PR DESCRIPTION
### What changed? Why?

This adds a correlation context header that includes the version
and language of the SDK.

This will be used to track what versions of the SDK developers are
using and to help reach out to upgrade versions.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
