### PR TITLE
Decouple create transfer/trade from wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
   This is especially important for External Address use-case where tx signing and broadcast status is maintained on client side, and we risk overwriting the existing txs.
 - Increase default timeout for `createStakingOperation` to 10 min.
 
+### Changed
+- The `createTransfer` and `createTrade` functions no longer wait for the transactions to confirm or
+  fail on-chain.
+  - Now they return a `Transfer` and `Trade` object respectively, which support the `wait`
+    function, e.g. `await transfer.wait()`.
+
 ## [0.0.16] - 2024-08-14
 
 ### Added

--- a/quickstart-template/index.js
+++ b/quickstart-template/index.js
@@ -23,4 +23,7 @@ const transfer = await wallet.createTransfer({
   destination: anotherWallet,
 });
 
+// Wait for the transfer to complete or fail on-chain.
+await transfer.wait();
+
 console.log(`Transfer successfully completed: `, transfer.toString());

--- a/quickstart-template/mass-payout.js
+++ b/quickstart-template/mass-payout.js
@@ -66,12 +66,15 @@ async function sendMassPayout(sendingWallet) {
       const address = row[0];
       if (address) {
         try {
-          await sendingWallet.createTransfer({
+          const transfer = await sendingWallet.createTransfer({
             // Send payment to each Address in CSV.
             amount: transferAmount,
             assetId: assetId,
             destination: address,
           });
+
+          await transfer.wait();
+
           console.log(`Transfer to ${address} successful`);
         } catch (error) {
           console.error(`Error transferring to ${address}: `, error);

--- a/quickstart-template/trade-assets.js
+++ b/quickstart-template/trade-assets.js
@@ -10,4 +10,8 @@ let wallet = await Wallet.create({ networkId: Coinbase.networks.BaseMainnet });
  * Trade 0.00001 ETH to USDC.
  */
 let trade = await wallet.createTrade(0.00001, Coinbase.assets.Eth, Coinbase.assets.Usdc);
+
+// Wait for the trade to complete or fail on-chain.
+await trade.wait();
+
 console.log(`Trade successfully completed: `, trade.toString());

--- a/src/coinbase/errors.ts
+++ b/src/coinbase/errors.ts
@@ -1,5 +1,5 @@
 /**
- * InvalidaAPIKeyFormat error is thrown when the API key format is invalid.
+ * InvalidAPIKeyFormat error is thrown when the API key format is invalid.
  */
 export class InvalidAPIKeyFormat extends Error {
   static DEFAULT_MESSAGE = "Invalid API key format";
@@ -14,6 +14,24 @@ export class InvalidAPIKeyFormat extends Error {
     this.name = "InvalidAPIKeyFormat";
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, InvalidAPIKeyFormat);
+    }
+  }
+}
+
+/**
+ * TimeoutError is thrown when an operation times out.
+ */
+export class TimeoutError extends Error {
+  /**
+   * Initializes a new TimeoutError instance.
+   *
+   * @param message - The error message.
+   */
+  constructor(message: string = "Timeout Error") {
+    super(message);
+    this.name = "TimeoutError";
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, TimeoutError);
     }
   }
 }
@@ -94,6 +112,24 @@ export class InvalidUnsignedPayload extends Error {
     this.name = "InvalidUnsignedPayload";
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, InvalidUnsignedPayload);
+    }
+  }
+}
+
+/**
+ * NotSignedError is thrown when a resource is not signed.
+ */
+export class NotSignedError extends Error {
+  /**
+   * Initializes a new NotSignedError instance.
+   *
+   * @param message - The error message.
+   */
+  constructor(message: string = "Resource not signed") {
+    super(message);
+    this.name = "NotSignedError";
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, NotSignedError);
     }
   }
 }

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -295,35 +295,22 @@ export class Wallet {
   }
 
   /**
-   *  Trades the given amount of the given Asset for another Asset. Currently only the default address is used to source the Trade
+   *  Trades the given amount of the given Asset for another Asset.
+   *  Currently only the default address is used to source the Trade.
    *
    * @param options - The options to create the Trade.
    * @param options.amount - The amount of the Asset to send.
    * @param options.fromAssetId - The ID of the Asset to trade from.
    * @param options.toAssetId - The ID of the Asset to trade to.
-   * @param options.timeoutSeconds - The maximum amount of time to wait for the Trade to complete, in seconds.
-   * @param options.intervalSeconds - The interval at which to poll the Network for Trade status, in seconds.
    * @throws {InternalError} If the default address is not found.
    * @throws {Error} If the private key is not loaded, or if the asset IDs are unsupported, or if there are insufficient funds.
-   * @returns The Trade object.
+   * @returns The created Trade object.
    */
-  public async createTrade({
-    amount,
-    fromAssetId,
-    toAssetId,
-    timeoutSeconds = 10,
-    intervalSeconds = 0.2,
-  }: CreateTradeOptions): Promise<Trade> {
+  public async createTrade(options: CreateTradeOptions): Promise<Trade> {
     if (!this.getDefaultAddress()) {
       throw new InternalError("Default address not found");
     }
-    return await this.getDefaultAddress()!.createTrade({
-      amount: amount,
-      fromAssetId: fromAssetId,
-      toAssetId: toAssetId,
-      timeoutSeconds,
-      intervalSeconds,
-    });
+    return await this.getDefaultAddress()!.createTrade(options);
   }
 
   /**
@@ -756,33 +743,17 @@ export class Wallet {
    * @param options.amount - The amount of the Asset to send.
    * @param options.assetId - The ID of the Asset to send.
    * @param options.destination - The destination of the transfer. If a Wallet, sends to the Wallet's default address. If a String, interprets it as the address ID.
-   * @param options.timeoutSeconds - The maximum amount of time to wait for the Transfer to complete, in seconds.
-   * @param options.intervalSeconds - The interval at which to poll the Network for Transfer status, in seconds.
    * @param options.gasless - Whether the Transfer should be gasless. Defaults to false.
-   * @returns The hash of the Transfer transaction.
+   * @returns The created Transfer object.
    * @throws {APIError} if the API request to create a Transfer fails.
    * @throws {APIError} if the API request to broadcast a Transfer fails.
-   * @throws {Error} if the Transfer times out.
    */
-  public async createTransfer({
-    amount,
-    assetId,
-    destination,
-    timeoutSeconds = 10,
-    intervalSeconds = 0.2,
-    gasless = false,
-  }: CreateTransferOptions): Promise<Transfer> {
+  public async createTransfer(options: CreateTransferOptions): Promise<Transfer> {
     if (!this.getDefaultAddress()) {
       throw new InternalError("Default address not found");
     }
-    return await this.getDefaultAddress()!.createTransfer({
-      amount,
-      assetId,
-      destination,
-      timeoutSeconds,
-      intervalSeconds,
-      gasless,
-    });
+
+    return await this.getDefaultAddress()!.createTransfer(options);
   }
 
   /**

--- a/src/examples/trade_assets.js
+++ b/src/examples/trade_assets.js
@@ -13,6 +13,10 @@ async function tradeAssets() {
     fromAssetId: Coinbase.assets.Eth,
     toAssetId: Coinbase.assets.Usdc,
   });
+
+  // Wait for the trade to complete or fail on-chain.
+  await trade.wait();
+
   console.log(`Trade successfully completed: `, trade.toString());
 }
 

--- a/src/examples/transfer_funds.js
+++ b/src/examples/transfer_funds.js
@@ -19,6 +19,10 @@ async function transferFunds() {
     assetId: Coinbase.assets.Eth,
     destination: anotherWallet,
   });
+
+  // Wait for the transfer to complete or fail on-chain.
+  await transfer.wait();
+
   console.log(`Transfer successfully completed: `, transfer.toString());
 }
 

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -89,6 +89,9 @@ describe("Coinbase SDK E2E Test", () => {
       assetId: Coinbase.assets.Eth,
       destination: wallet,
     });
+
+    await transfer.wait();
+
     expect(transfer.toString()).toBeDefined();
     expect(await transfer.getStatus()).toBe(TransferStatus.COMPLETE);
     console.log(`Transferred 1 Gwei from ${unhydratedWallet} to ${wallet}`);


### PR DESCRIPTION


### What changed? Why?
This decouples the action of creating a transfer or trade object from the actual waiting for it to confirm or fail on-chain.

Without this we cannot create many transfer concurrently without running into a plethora of 429 issues.

We also cannot recover gracefully since we never get the transfer object returns, so cannot subsequently make fetches for its status if it happens to fail (or returns a temporary error, e.g. 429).

TODO:
* [x] Add `Trade#sign` and `Transfer#broadcast` unit tests

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
