### PR TITLE
[hotfix] patch for setting page

### DIFF
--- a/src/coinbase/address.ts
+++ b/src/coinbase/address.ts
@@ -104,12 +104,12 @@ export class Address {
   }: ListHistoricalBalancesOptions): Promise<ListHistoricalBalancesResult> {
     const historyList: HistoricalBalance[] = [];
 
-    if (limit !== undefined) {
+    if (limit !== undefined || page !== undefined) {
       const response = await Coinbase.apiClients.externalAddress!.listAddressHistoricalBalance(
         this.getNetworkId(),
         this.getId(),
         Asset.primaryDenomination(assetId),
-        limit,
+        limit ? limit : undefined,
         page ? page : undefined,
       );
 

--- a/src/tests/address_test.ts
+++ b/src/tests/address_test.ts
@@ -70,7 +70,7 @@ describe("Address", () => {
       );
     });
 
-    it("should return results with USDC historical balance", async () => {
+    it("should return results with USDC historical balance with limit", async () => {
       const historicalBalancesResult = await address.listHistoricalBalances({
         assetId: Coinbase.assets.Usdc,
       });
@@ -88,6 +88,29 @@ describe("Address", () => {
         Coinbase.assets.Usdc,
         100,
         undefined,
+      );
+      expect(historicalBalancesResult.nextPageToken).toEqual("");
+    });
+
+    it("should return results with USDC historical balance with page", async () => {
+      const historicalBalancesResult = await address.listHistoricalBalances({
+        assetId: Coinbase.assets.Usdc,
+        page: "page_token",
+      });
+      expect(historicalBalancesResult.historicalBalances.length).toEqual(2);
+      expect(historicalBalancesResult.historicalBalances[0].amount).toEqual(new Decimal(1));
+      expect(historicalBalancesResult.historicalBalances[1].amount).toEqual(new Decimal(5));
+      expect(
+        Coinbase.apiClients.externalAddress!.listAddressHistoricalBalance,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        Coinbase.apiClients.externalAddress!.listAddressHistoricalBalance,
+      ).toHaveBeenCalledWith(
+        address.getNetworkId(),
+        address.getId(),
+        Coinbase.assets.Usdc,
+        undefined,
+        "page_token",
       );
       expect(historicalBalancesResult.nextPageToken).toEqual("");
     });


### PR DESCRIPTION
### What changed? Why?
Hotfix for setting page option for listHistoricalBalances

> let historicalBalancesResult = address.listHistoricalBalances({assetId: 'usdc', 'page': '123123'});
undefined
> Uncaught InternalError: Request failed with status code 500
    at Function.fromError (/Users/xinyu.li@coinbase.com/ext/coinbase-sdk-nodejs/src/coinbase/api_error.ts:60:16)
    at /Users/xinyu.li@coinbase.com/ext/coinbase-sdk-nodejs/src/coinbase/utils.ts:61:36
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Axios.request (/Users/xinyu.li@coinbase.com/ext/coinbase-sdk-nodejs/node_modules/axios/lib/core/Axios.js:40:14)
    at async Address.listHistoricalBalances (/Users/xinyu.li@coinbase.com/ext/coinbase-sdk-nodejs/src/coinbase/address.ts:108:24)

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
