### PR TITLE
[chore] Enable E2E test manual dispatch

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,6 +1,10 @@
 name: Run E2E Tests
 
-on: [pull_request]
+on:
+  # Ensures runs on every pull request.
+  pull_request:
+  # Enables manual invocation of workflow via Github UI and API.
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION

### What changed? Why?
This adds support for initiating E2E tests manually from the Github Actions UI.

This is useful for running tests against the `master` branch when a PR hasn't been opened up in a while.


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
