### PR TITLE
[hotfix] Bump quickstart template SDK version

### DIFF
--- a/quickstart-template/package.json
+++ b/quickstart-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickstart-template",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -14,7 +14,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "@coinbase/coinbase-sdk": "^0.0.13",
+    "@coinbase/coinbase-sdk": "^0.1.0",
     "csv-parse": "^5.5.6",
     "csv-writer": "^1.6.0"
   }


### PR DESCRIPTION


### What changed? Why?
This bumps the quick start template's SDK version to use `v0.1.0`

When we release a new SDK version, we should separately fast follow with quickstart changes, rather than include them before the SDK is released in order to avoid this situation.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
