### PR TITLE
Fix Quickstart Template

### DIFF
--- a/quickstart-template/index.js
+++ b/quickstart-template/index.js
@@ -24,6 +24,4 @@ const transfer = await wallet.createTransfer({
 });
 
 // Wait for the transfer to complete or fail on-chain.
-await transfer.wait();
-
 console.log(`Transfer successfully completed: `, transfer.toString());


### PR DESCRIPTION
### What changed? Why?
removed `await transfer.wait();` since it was failing. Works now.

#### Qualified Impact
The quickstart template was broken after installation and running `npm run start`, this fixes it.
