### PR TITLE
[wip] Support contract invocations

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -200,6 +200,19 @@ export interface Balance {
 /**
  * 
  * @export
+ * @interface BroadcastContractInvocationRequest
+ */
+export interface BroadcastContractInvocationRequest {
+    /**
+     * The hex-encoded signed payload of the contract invocation
+     * @type {string}
+     * @memberof BroadcastContractInvocationRequest
+     */
+    'signed_payload': string;
+}
+/**
+ * 
+ * @export
  * @interface BroadcastStakingOperationRequest
  */
 export interface BroadcastStakingOperationRequest {
@@ -396,6 +409,98 @@ export interface ContractEventList {
     'has_more': boolean;
 }
 /**
+ * A contract invocation onchain.
+ * @export
+ * @interface ContractInvocation
+ */
+export interface ContractInvocation {
+    /**
+     * The ID of the blockchain network.
+     * @type {string}
+     * @memberof ContractInvocation
+     */
+    'network_id': string;
+    /**
+     * The ID of the wallet that owns the address.
+     * @type {string}
+     * @memberof ContractInvocation
+     */
+    'wallet_id': string;
+    /**
+     * The onchain address of the address invoking the contract.
+     * @type {string}
+     * @memberof ContractInvocation
+     */
+    'address_id': string;
+    /**
+     * The ID of the contract invocation.
+     * @type {string}
+     * @memberof ContractInvocation
+     */
+    'contract_invocation_id': string;
+    /**
+     * The onchain address of the contract.
+     * @type {string}
+     * @memberof ContractInvocation
+     */
+    'contract_address': string;
+    /**
+     * The method to be invoked on the contract.
+     * @type {string}
+     * @memberof ContractInvocation
+     */
+    'method': string;
+    /**
+     * The arguments to be passed to the contract method.
+     * @type {Array<string>}
+     * @memberof ContractInvocation
+     */
+    'args': Array<string>;
+    /**
+     * The JSON-encoded ABI of the contract.
+     * @type {string}
+     * @memberof ContractInvocation
+     */
+    'abi'?: string;
+    /**
+     * 
+     * @type {Transaction}
+     * @memberof ContractInvocation
+     */
+    'transaction': Transaction;
+}
+/**
+ * 
+ * @export
+ * @interface ContractInvocationList
+ */
+export interface ContractInvocationList {
+    /**
+     * 
+     * @type {Array<ContractInvocation>}
+     * @memberof ContractInvocationList
+     */
+    'data': Array<ContractInvocation>;
+    /**
+     * True if this list has another page of items after this one that can be fetched.
+     * @type {boolean}
+     * @memberof ContractInvocationList
+     */
+    'has_more': boolean;
+    /**
+     * The page token to be used to fetch the next page.
+     * @type {string}
+     * @memberof ContractInvocationList
+     */
+    'next_page': string;
+    /**
+     * The total number of contract invocations for the address in the wallet.
+     * @type {number}
+     * @memberof ContractInvocationList
+     */
+    'total_count': number;
+}
+/**
  * 
  * @export
  * @interface CreateAddressRequest
@@ -419,6 +524,37 @@ export interface CreateAddressRequest {
      * @memberof CreateAddressRequest
      */
     'address_index'?: number;
+}
+/**
+ * 
+ * @export
+ * @interface CreateContractInvocationRequest
+ */
+export interface CreateContractInvocationRequest {
+    /**
+     * The address of the contract to invoke.
+     * @type {string}
+     * @memberof CreateContractInvocationRequest
+     */
+    'contract_address': string;
+    /**
+     * The method to invoke on the contract.
+     * @type {string}
+     * @memberof CreateContractInvocationRequest
+     */
+    'method': string;
+    /**
+     * The arguments to pass to the contract method.
+     * @type {Array<string>}
+     * @memberof CreateContractInvocationRequest
+     */
+    'args': Array<string>;
+    /**
+     * The JSON-encoded ABI of the contract.
+     * @type {string}
+     * @memberof CreateContractInvocationRequest
+     */
+    'abi'?: string;
 }
 /**
  * 
@@ -601,7 +737,7 @@ export interface CreateWebhookRequest {
      */
     'notification_uri': string;
     /**
-     * The custom header to be used for x-webhook-signature header on callbacks,  so developers can verify the requests are coming from Coinbase.
+     * The custom header to be used for x-webhook-signature header on callbacks, so developers can verify the requests are coming from Coinbase.
      * @type {string}
      * @memberof CreateWebhookRequest
      */
@@ -3145,6 +3281,455 @@ export class ContractEventsApi extends BaseAPI implements ContractEventsApiInter
      */
     public listContractEvents(networkId: string, protocolName: string, contractAddress: string, contractName: string, eventName: string, fromBlockHeight: number, toBlockHeight: number, nextPage?: string, options?: RawAxiosRequestConfig) {
         return ContractEventsApiFp(this.configuration).listContractEvents(networkId, protocolName, contractAddress, contractName, eventName, fromBlockHeight, toBlockHeight, nextPage, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
+ * ContractInvocationsApi - axios parameter creator
+ * @export
+ */
+export const ContractInvocationsApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * Broadcast a contract invocation.
+         * @summary Broadcast a contract invocation.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address the contract invocation belongs to.
+         * @param {string} contractInvocationId The ID of the contract invocation to broadcast.
+         * @param {BroadcastContractInvocationRequest} broadcastContractInvocationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        broadcastContractInvocation: async (walletId: string, addressId: string, contractInvocationId: string, broadcastContractInvocationRequest: BroadcastContractInvocationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('broadcastContractInvocation', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('broadcastContractInvocation', 'addressId', addressId)
+            // verify required parameter 'contractInvocationId' is not null or undefined
+            assertParamExists('broadcastContractInvocation', 'contractInvocationId', contractInvocationId)
+            // verify required parameter 'broadcastContractInvocationRequest' is not null or undefined
+            assertParamExists('broadcastContractInvocation', 'broadcastContractInvocationRequest', broadcastContractInvocationRequest)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/contract_invocations/{contract_invocation_id}/broadcast`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)))
+                .replace(`{${"contract_invocation_id"}}`, encodeURIComponent(String(contractInvocationId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(broadcastContractInvocationRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Create a new contract invocation.
+         * @summary Create a new contract invocation for an address.
+         * @param {string} walletId The ID of the wallet the source address belongs to.
+         * @param {string} addressId The ID of the address to invoke the contract from.
+         * @param {CreateContractInvocationRequest} createContractInvocationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createContractInvocation: async (walletId: string, addressId: string, createContractInvocationRequest: CreateContractInvocationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('createContractInvocation', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('createContractInvocation', 'addressId', addressId)
+            // verify required parameter 'createContractInvocationRequest' is not null or undefined
+            assertParamExists('createContractInvocation', 'createContractInvocationRequest', createContractInvocationRequest)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/contract_invocations`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(createContractInvocationRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Get a contract invocation by ID.
+         * @summary Get a contract invocation by ID.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address the contract invocation belongs to.
+         * @param {string} contractInvocationId The ID of the contract invocation to fetch.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getContractInvocation: async (walletId: string, addressId: string, contractInvocationId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('getContractInvocation', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('getContractInvocation', 'addressId', addressId)
+            // verify required parameter 'contractInvocationId' is not null or undefined
+            assertParamExists('getContractInvocation', 'contractInvocationId', contractInvocationId)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/contract_invocations/{contract_invocation_id}`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)))
+                .replace(`{${"contract_invocation_id"}}`, encodeURIComponent(String(contractInvocationId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * List contract invocations for an address.
+         * @summary List contract invocations for an address.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address to list contract invocations for.
+         * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+         * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listContractInvocations: async (walletId: string, addressId: string, limit?: number, page?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('listContractInvocations', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('listContractInvocations', 'addressId', addressId)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/contract_invocations`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (limit !== undefined) {
+                localVarQueryParameter['limit'] = limit;
+            }
+
+            if (page !== undefined) {
+                localVarQueryParameter['page'] = page;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * ContractInvocationsApi - functional programming interface
+ * @export
+ */
+export const ContractInvocationsApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = ContractInvocationsApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * Broadcast a contract invocation.
+         * @summary Broadcast a contract invocation.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address the contract invocation belongs to.
+         * @param {string} contractInvocationId The ID of the contract invocation to broadcast.
+         * @param {BroadcastContractInvocationRequest} broadcastContractInvocationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async broadcastContractInvocation(walletId: string, addressId: string, contractInvocationId: string, broadcastContractInvocationRequest: BroadcastContractInvocationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ContractInvocation>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.broadcastContractInvocation(walletId, addressId, contractInvocationId, broadcastContractInvocationRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['ContractInvocationsApi.broadcastContractInvocation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Create a new contract invocation.
+         * @summary Create a new contract invocation for an address.
+         * @param {string} walletId The ID of the wallet the source address belongs to.
+         * @param {string} addressId The ID of the address to invoke the contract from.
+         * @param {CreateContractInvocationRequest} createContractInvocationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async createContractInvocation(walletId: string, addressId: string, createContractInvocationRequest: CreateContractInvocationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ContractInvocation>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createContractInvocation(walletId, addressId, createContractInvocationRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['ContractInvocationsApi.createContractInvocation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Get a contract invocation by ID.
+         * @summary Get a contract invocation by ID.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address the contract invocation belongs to.
+         * @param {string} contractInvocationId The ID of the contract invocation to fetch.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getContractInvocation(walletId: string, addressId: string, contractInvocationId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ContractInvocation>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getContractInvocation(walletId, addressId, contractInvocationId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['ContractInvocationsApi.getContractInvocation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * List contract invocations for an address.
+         * @summary List contract invocations for an address.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address to list contract invocations for.
+         * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+         * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async listContractInvocations(walletId: string, addressId: string, limit?: number, page?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ContractInvocationList>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listContractInvocations(walletId, addressId, limit, page, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['ContractInvocationsApi.listContractInvocations']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * ContractInvocationsApi - factory interface
+ * @export
+ */
+export const ContractInvocationsApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = ContractInvocationsApiFp(configuration)
+    return {
+        /**
+         * Broadcast a contract invocation.
+         * @summary Broadcast a contract invocation.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address the contract invocation belongs to.
+         * @param {string} contractInvocationId The ID of the contract invocation to broadcast.
+         * @param {BroadcastContractInvocationRequest} broadcastContractInvocationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        broadcastContractInvocation(walletId: string, addressId: string, contractInvocationId: string, broadcastContractInvocationRequest: BroadcastContractInvocationRequest, options?: any): AxiosPromise<ContractInvocation> {
+            return localVarFp.broadcastContractInvocation(walletId, addressId, contractInvocationId, broadcastContractInvocationRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Create a new contract invocation.
+         * @summary Create a new contract invocation for an address.
+         * @param {string} walletId The ID of the wallet the source address belongs to.
+         * @param {string} addressId The ID of the address to invoke the contract from.
+         * @param {CreateContractInvocationRequest} createContractInvocationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createContractInvocation(walletId: string, addressId: string, createContractInvocationRequest: CreateContractInvocationRequest, options?: any): AxiosPromise<ContractInvocation> {
+            return localVarFp.createContractInvocation(walletId, addressId, createContractInvocationRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Get a contract invocation by ID.
+         * @summary Get a contract invocation by ID.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address the contract invocation belongs to.
+         * @param {string} contractInvocationId The ID of the contract invocation to fetch.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getContractInvocation(walletId: string, addressId: string, contractInvocationId: string, options?: any): AxiosPromise<ContractInvocation> {
+            return localVarFp.getContractInvocation(walletId, addressId, contractInvocationId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * List contract invocations for an address.
+         * @summary List contract invocations for an address.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The ID of the address to list contract invocations for.
+         * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+         * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listContractInvocations(walletId: string, addressId: string, limit?: number, page?: string, options?: any): AxiosPromise<ContractInvocationList> {
+            return localVarFp.listContractInvocations(walletId, addressId, limit, page, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * ContractInvocationsApi - interface
+ * @export
+ * @interface ContractInvocationsApi
+ */
+export interface ContractInvocationsApiInterface {
+    /**
+     * Broadcast a contract invocation.
+     * @summary Broadcast a contract invocation.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address the contract invocation belongs to.
+     * @param {string} contractInvocationId The ID of the contract invocation to broadcast.
+     * @param {BroadcastContractInvocationRequest} broadcastContractInvocationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ContractInvocationsApiInterface
+     */
+    broadcastContractInvocation(walletId: string, addressId: string, contractInvocationId: string, broadcastContractInvocationRequest: BroadcastContractInvocationRequest, options?: RawAxiosRequestConfig): AxiosPromise<ContractInvocation>;
+
+    /**
+     * Create a new contract invocation.
+     * @summary Create a new contract invocation for an address.
+     * @param {string} walletId The ID of the wallet the source address belongs to.
+     * @param {string} addressId The ID of the address to invoke the contract from.
+     * @param {CreateContractInvocationRequest} createContractInvocationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ContractInvocationsApiInterface
+     */
+    createContractInvocation(walletId: string, addressId: string, createContractInvocationRequest: CreateContractInvocationRequest, options?: RawAxiosRequestConfig): AxiosPromise<ContractInvocation>;
+
+    /**
+     * Get a contract invocation by ID.
+     * @summary Get a contract invocation by ID.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address the contract invocation belongs to.
+     * @param {string} contractInvocationId The ID of the contract invocation to fetch.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ContractInvocationsApiInterface
+     */
+    getContractInvocation(walletId: string, addressId: string, contractInvocationId: string, options?: RawAxiosRequestConfig): AxiosPromise<ContractInvocation>;
+
+    /**
+     * List contract invocations for an address.
+     * @summary List contract invocations for an address.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address to list contract invocations for.
+     * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+     * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ContractInvocationsApiInterface
+     */
+    listContractInvocations(walletId: string, addressId: string, limit?: number, page?: string, options?: RawAxiosRequestConfig): AxiosPromise<ContractInvocationList>;
+
+}
+
+/**
+ * ContractInvocationsApi - object-oriented interface
+ * @export
+ * @class ContractInvocationsApi
+ * @extends {BaseAPI}
+ */
+export class ContractInvocationsApi extends BaseAPI implements ContractInvocationsApiInterface {
+    /**
+     * Broadcast a contract invocation.
+     * @summary Broadcast a contract invocation.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address the contract invocation belongs to.
+     * @param {string} contractInvocationId The ID of the contract invocation to broadcast.
+     * @param {BroadcastContractInvocationRequest} broadcastContractInvocationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ContractInvocationsApi
+     */
+    public broadcastContractInvocation(walletId: string, addressId: string, contractInvocationId: string, broadcastContractInvocationRequest: BroadcastContractInvocationRequest, options?: RawAxiosRequestConfig) {
+        return ContractInvocationsApiFp(this.configuration).broadcastContractInvocation(walletId, addressId, contractInvocationId, broadcastContractInvocationRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Create a new contract invocation.
+     * @summary Create a new contract invocation for an address.
+     * @param {string} walletId The ID of the wallet the source address belongs to.
+     * @param {string} addressId The ID of the address to invoke the contract from.
+     * @param {CreateContractInvocationRequest} createContractInvocationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ContractInvocationsApi
+     */
+    public createContractInvocation(walletId: string, addressId: string, createContractInvocationRequest: CreateContractInvocationRequest, options?: RawAxiosRequestConfig) {
+        return ContractInvocationsApiFp(this.configuration).createContractInvocation(walletId, addressId, createContractInvocationRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Get a contract invocation by ID.
+     * @summary Get a contract invocation by ID.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address the contract invocation belongs to.
+     * @param {string} contractInvocationId The ID of the contract invocation to fetch.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ContractInvocationsApi
+     */
+    public getContractInvocation(walletId: string, addressId: string, contractInvocationId: string, options?: RawAxiosRequestConfig) {
+        return ContractInvocationsApiFp(this.configuration).getContractInvocation(walletId, addressId, contractInvocationId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * List contract invocations for an address.
+     * @summary List contract invocations for an address.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The ID of the address to list contract invocations for.
+     * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+     * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ContractInvocationsApi
+     */
+    public listContractInvocations(walletId: string, addressId: string, limit?: number, page?: string, options?: RawAxiosRequestConfig) {
+        return ContractInvocationsApiFp(this.configuration).listContractInvocations(walletId, addressId, limit, page, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/src/coinbase/coinbase.ts
+++ b/src/coinbase/coinbase.ts
@@ -15,6 +15,7 @@ import {
   WebhooksApiFactory,
   NetworkIdentifier,
   ContractEventsApiFactory,
+  ContractInvocationsApiFactory,
 } from "../client";
 import { BASE_PATH } from "./../client/base";
 import { Configuration } from "./../client/configuration";
@@ -128,6 +129,11 @@ export class Coinbase {
     Coinbase.apiClients.validator = ValidatorsApiFactory(config, basePath, axiosInstance);
     Coinbase.apiClients.asset = AssetsApiFactory(config, basePath, axiosInstance);
     Coinbase.apiClients.webhook = WebhooksApiFactory(config, basePath, axiosInstance);
+    Coinbase.apiClients.contractInvocation = ContractInvocationsApiFactory(
+      config,
+      basePath,
+      axiosInstance
+    );
     Coinbase.apiClients.externalAddress = ExternalAddressesApiFactory(
       config,
       basePath,

--- a/src/coinbase/contractInvocation.ts
+++ b/src/coinbase/contractInvocation.ts
@@ -1,0 +1,255 @@
+import { Decimal } from "decimal.js";
+import { TransactionStatus } from "./types";
+import { Transaction } from "./transaction";
+import { Coinbase } from "./coinbase";
+import { ContractInvocation as ContractInvocationModel } from "../client/api";
+import { ethers } from "ethers";
+import { delay } from "./utils";
+import { InternalError, TimeoutError } from "./errors";
+
+/**
+ * A representation of a ContractInvocation, which moves an Amount of an Asset from
+ * a user-controlled Wallet to another Address. The fee is assumed to be paid
+ * in the native Asset of the Network.
+ */
+export class ContractInvocation {
+  private model: ContractInvocationModel;
+
+  /**
+   * Private constructor to prevent direct instantiation outside of the factory methods.
+   *
+   * @ignore
+   * @param contractInvocationModel - The ContractInvocation model.
+   * @hideconstructor
+   */
+  private constructor(contractInvocationModel: ContractInvocationModel) {
+    if (!contractInvocationModel) {
+      throw new InternalError("ContractInvocation model cannot be empty");
+    }
+    this.model = contractInvocationModel;
+  }
+
+  /**
+   * Converts a ContractInvocationModel into a ContractInvocation object.
+   *
+   * @param contractInvocationModel - The ContractInvocation model object.
+   * @returns The ContractInvocation object.
+   */
+  public static fromModel(contractInvocationModel: ContractInvocationModel): ContractInvocation {
+    return new ContractInvocation(contractInvocationModel);
+  }
+
+  /**
+   * Returns the ID of the ContractInvocation.
+   *
+   * @returns The ContractInvocation ID.
+   */
+  public getId(): string {
+    return this.model.contract_invocation_id;
+  }
+
+  /**
+   * Returns the Network ID of the ContractInvocation.
+   *
+   * @returns The Network ID.
+   */
+  public getNetworkId(): string {
+    return this.model.network_id;
+  }
+
+  /**
+   * Returns the Wallet ID of the ContractInvocation.
+   *
+   * @returns The Wallet ID.
+   */
+  public getWalletId(): string {
+    return this.model.wallet_id;
+  }
+
+  /**
+   * Returns the From Address ID of the ContractInvocation.
+   *
+   * @returns The From Address ID.
+   */
+  public getFromAddressId(): string {
+    return this.model.address_id;
+  }
+
+  /**
+   * Returns the Destination Address ID of the ContractInvocation.
+   *
+   * @returns The Destination Address ID.
+   */
+  public getContractAddressId(): string {
+    return this.model.contract_address;
+  }
+
+  /**
+   * Returns the Method of the ContractInvocation.
+   *
+   * @returns The Method.
+   * @throws {InternalError} if the Method is not available.
+   */
+  public getMethod(): string {
+    return this.model.method;
+  }
+
+  /**
+   * Returns the Arguments of the ContractInvocation.
+   *
+   * @returns {string[]} The list of arguments.
+   */
+  public getArgs(): string[] {
+    return this.model.args;
+  }
+
+  /**
+   * Returns the ABI of the ContractInvocation, if specified.
+   *
+   * @returns The ABI as an object, or undefined if not available.
+   */
+  public getAbi(): object | undefined {
+    if (!this.model.abi) return undefined;
+
+    return JSON.parse(this.model.abi);
+  }
+
+  /**
+   * Returns the Transaction Hash of the ContractInvocation.
+   *
+   * @returns The Transaction Hash as a Hex string, or undefined if not yet available.
+   */
+  public getTransactionHash(): string | undefined {
+    return this.getTransaction().getTransactionHash();
+  }
+
+  /**
+   * Returns the Transaction of the ContractInvocation.
+   *
+   * @returns The ethers.js Transaction object.
+   * @throws (InvalidUnsignedPayload) If the Unsigned Payload is invalid.
+   */
+  public getRawTransaction(): ethers.Transaction {
+    return this.getTransaction().rawTransaction();
+  }
+
+  /**
+   * Signs the ContractInvocation with the provided key and returns the hex signature
+   * required for broadcasting the ContractInvocation.
+   *
+   * @param key - The key to sign the ContractInvocation with
+   * @returns The hex-encoded signed payload
+   */
+  async sign(key: ethers.Wallet): Promise<string> {
+    return this.getTransaction().sign(key);
+  }
+
+  /**
+   * Returns the Status of the ContractInvocation.
+   *
+   * @returns The Status of the ContractInvocation.
+   */
+  public getStatus(): TransactionStatus | undefined {
+    return this.getTransaction().getStatus();
+  }
+
+  /**
+   * Returns the Transaction of the ContractInvocation.
+   *
+   * @returns The Transaction
+   */
+  public getTransaction(): Transaction {
+    return new Transaction(this.model.transaction);
+  }
+
+  /**
+   * Returns the link to the Transaction on the blockchain explorer.
+   *
+   * @returns The link to the Transaction on the blockchain explorer.
+   */
+  public getTransactionLink(): string {
+    return this.getTransaction().getTransactionLink();
+  }
+
+  /**
+   * Broadcasts the ContractInvocation to the Network.
+   *
+   * @returns The ContractInvocation object
+   * @throws {APIError} if the API request to broadcast a ContractInvocation fails.
+   */
+  public async broadcast(): Promise<ContractInvocation> {
+    if (!this.getTransaction()?.isSigned())
+      throw new Error("Cannot broadcast unsigned ContractInvocation");
+
+    const broadcastContractInvocationRequest = {
+      signed_payload: this.getTransaction()!.getSignature()!,
+    };
+
+    const response = await Coinbase.apiClients.contractInvocation!.broadcastContractInvocation(
+      this.getWalletId(),
+      this.getFromAddressId(),
+      this.getId(),
+      broadcastContractInvocationRequest,
+    );
+
+    return ContractInvocation.fromModel(response.data);
+  }
+
+  /**
+   * Waits for the ContractInvocation to be confirmed on the Network or fail on chain.
+   * Waits until the ContractInvocation is completed or failed on-chain by polling at the given interval.
+   * Raises an error if the Trade takes longer than the given timeout.
+   *
+   * @param options - The options to configure the wait function.
+   * @param options.intervalSeconds - The interval to check the status of the ContractInvocation.
+   * @param options.timeoutSeconds - The maximum time to wait for the ContractInvocation to be confirmed.
+   *
+   * @returns The ContractInvocation object in a terminal state.
+   * @throws {Error} if the ContractInvocation times out.
+   */
+  public async wait({ intervalSeconds = 0.2, timeoutSeconds = 10 } = {}): Promise<ContractInvocation> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutSeconds * 1000) {
+      await this.reload();
+
+      // If the ContractInvocation is in a terminal state, return the ContractInvocation.
+      const status = this.getStatus();
+      if (status === TransactionStatus.COMPLETE || status === TransactionStatus.FAILED) {
+        return this;
+      }
+
+      await delay(intervalSeconds);
+    }
+
+    throw new TimeoutError("ContractInvocation timed out");
+  }
+
+  /**
+   * Reloads the ContractInvocation model with the latest data from the server.
+   *
+   * @throws {APIError} if the API request to get a ContractInvocation fails.
+   */
+  public async reload(): Promise<void> {
+    const result = await Coinbase.apiClients.contractInvocation!.getContractInvocation(
+      this.getWalletId(),
+      this.getFromAddressId(),
+      this.getId(),
+    );
+    this.model = result?.data;
+  }
+
+  /**
+   * Returns a string representation of the ContractInvocation.
+   *
+   * @returns The string representation of the ContractInvocation.
+   */
+  public toString(): string {
+    return (
+      `ContractInvocation{contractInvocationId: '${this.getId()}', networkId: '${this.getNetworkId()}', ` +
+      `fromAddressId: '${this.getFromAddressId()}', contractAddressId: '${this.getContractAddressId()}', ` +
+      `method: '${this.getMethod()}', args: '${this.getArgs()}', transactionHash: '${this.getTransactionHash()}', ` +
+      `transactionLink: '${this.getTransactionLink()}', status: '${this.getStatus()}'}`
+    );
+  }
+}

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -39,6 +39,10 @@ import {
   CreateWebhookRequest,
   UpdateWebhookRequest,
   ContractEventList,
+  BroadcastContractInvocationRequest,
+  CreateContractInvocationRequest,
+  ContractInvocationList,
+  ContractInvocation as ContractInvocationModel,
 } from "./../client/api";
 import { Address } from "./address";
 import { Wallet } from "./wallet";
@@ -678,6 +682,7 @@ export type ApiClients = {
   externalAddress?: ExternalAddressAPIClient;
   webhook?: WebhookApiClient;
   smartContract?: ExternalSmartContractAPIClient;
+  contractInvocation?: ContractInvocationAPIClient;
 };
 
 /**
@@ -863,8 +868,6 @@ export type CreateTransferOptions = {
   amount: Amount;
   assetId: string;
   destination: Destination;
-  timeoutSeconds?: number;
-  intervalSeconds?: number;
   gasless?: boolean;
 };
 
@@ -875,9 +878,17 @@ export type CreateTradeOptions = {
   amount: Amount;
   fromAssetId: string;
   toAssetId: string;
-  timeoutSeconds?: number;
-  intervalSeconds?: number;
 };
+
+/**
+ * Options for creating a Contract Invocation.
+ */
+export type CreateContractInvocationOptions = {
+  contractAddress: string;
+  abi?: object;
+  method: string;
+  args: string[];
+}
 
 /**
  * Options for listing historical balances of an address.
@@ -950,3 +961,81 @@ export interface WebhookApiClient {
     options?: RawAxiosRequestConfig,
   ): AxiosPromise<WebhookModel>;
 }
+
+/**
+ * ContractInvocationAPI client type definition.
+ */
+export type ContractInvocationAPIClient = {
+  /**
+   * Broadcasts a contract invocation.
+   *
+   * @param walletId - The ID of the wallet the address belongs to.
+   * @param addressId - The ID of the address the contract invocation belongs to.
+   * @param contractInvocationId - The ID of the contract invocation to broadcast.
+   * @param broadcastContractInvocationRequest - The request body.
+   * @param options - Axios request options.
+   * @returns - A promise resolving to the ContractInvocation model.
+   * @throws {APIError} If the request fails.
+   */
+  broadcastContractInvocation(
+    walletId: string,
+    addressId: string,
+    contractInvocationId: string,
+    broadcastContractInvocationRequest: BroadcastContractInvocationRequest,
+    options?: AxiosRequestConfig,
+  ): AxiosPromise<ContractInvocationModel>;
+
+  /**
+   * Creates a Contract Invocation.
+   *
+   * @param walletId - The ID of the wallet the address belongs to.
+   * @param addressId - The ID of the address the contract invocation belongs to.
+   * @param createContractInvocationRequest - The request body.
+   * @param options - Axios request options.
+   * @returns - A promise resolving to the ContractInvocation model.
+   * @throws {APIError} If the request fails.
+   */
+  createContractInvocation(
+    walletId: string,
+    addressId: string,
+    createContractInvocationRequest: CreateContractInvocationRequest,
+    options?: AxiosRequestConfig,
+  ): AxiosPromise<ContractInvocationModel>;
+
+  /**
+   * Retrieves a Contract Invocation.
+   *
+   * @param walletId - The ID of the wallet the address belongs to.
+   * @param addressId - The ID of the address the contract invocation belongs to.
+   * @param contractInvocationId - The ID of the contract invocation to retrieve.
+   * @param options - Axios request options.
+   * @returns - A promise resolving to the ContractInvocation model.
+   * @throws {APIError} If the request fails.
+   */
+  getContractInvocation(
+    walletId: string,
+    addressId: string,
+    contractInvocationId: string,
+    options?: AxiosRequestConfig,
+  ): AxiosPromise<ContractInvocationModel>;
+
+  /**
+   * Lists Contract Invocations.
+   *
+   * @param walletId - The ID of the wallet the address belongs to.
+   * @param addressId - The ID of the address the contract invocations belong to.
+   * @param limit - The maximum number of contract invocations to return.
+   * @param page - The cursor for pagination across multiple pages of contract invocations.
+   * @param options - Axios request options.
+   * @returns - A promise resolving to the ContractInvocation list.
+   * @throws {APIError} If the request fails.
+   */
+  listContractInvocations(
+    walletId: string,
+    addressId: string,
+    limit?: number,
+    page?: string,
+    options?: AxiosRequestConfig,
+  ): AxiosPromise<ContractInvocationList>;
+};
+

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -501,7 +501,7 @@ describe("Wallet Class", () => {
   });
 
   describe(".createTransfer", () => {
-    let weiAmount, destination, intervalSeconds, timeoutSeconds;
+    let weiAmount, destination;
     let balanceModel: BalanceModel;
 
     beforeEach(() => {
@@ -509,8 +509,6 @@ describe("Wallet Class", () => {
       const key = ethers.Wallet.createRandom();
       weiAmount = new Decimal("5");
       destination = new WalletAddress(VALID_ADDRESS_MODEL, key as unknown as ethers.Wallet);
-      intervalSeconds = 0.2;
-      timeoutSeconds = 10;
       Coinbase.apiClients.externalAddress = externalAddressApiMock;
       Coinbase.apiClients.asset = assetsApiMock;
       Coinbase.apiClients.asset!.getAsset = getAssetMock();
@@ -563,8 +561,6 @@ describe("Wallet Class", () => {
           amount: weiAmount,
           assetId: Coinbase.assets.Wei,
           destination,
-          timeoutSeconds,
-          intervalSeconds,
         }),
       ).rejects.toThrow(APIError);
     });
@@ -579,8 +575,6 @@ describe("Wallet Class", () => {
           amount: weiAmount,
           assetId: Coinbase.assets.Wei,
           destination,
-          timeoutSeconds,
-          intervalSeconds,
         }),
       ).rejects.toThrow(APIError);
     });
@@ -592,8 +586,6 @@ describe("Wallet Class", () => {
           amount: insufficientAmount,
           assetId: Coinbase.assets.Wei,
           destination,
-          timeoutSeconds,
-          intervalSeconds,
         }),
       ).rejects.toThrow(ArgumentError);
     });
@@ -606,8 +598,6 @@ describe("Wallet Class", () => {
         amount: weiAmount,
         assetId: Coinbase.assets.Wei,
         destination,
-        timeoutSeconds,
-        intervalSeconds,
       });
 
       expect(Coinbase.apiClients.transfer!.createTransfer).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### What changed? Why?


Example usage
```
import { Coinbase, Wallet } from "./src/index";

Coinbase.configureFromJson();

const wallet = await Wallet.create();

await wallet.faucet();

const abi = [
  {
    inputs: [ { internalType: 'address', name: 'recipient', type: 'address' } ],
    name: 'mint',
    outputs: [ { internalType: 'uint256', name: '', type: 'uint256' } ],
    stateMutability: 'payable',
    type: 'function'
  }
]

const contractInvocation = await wallet.getDefaultAddress.invokeContract({
  abi,
  method: "mint",
  contractAddress: '0xa82aB8504fDeb2dADAa3B4F075E967BbE35065b9',
  args: ['0x475d41de7A81298Ba263184996800CBcaAD73C0b']
});

await contractInvocation.wait();
```


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
