### PR TITLE
Support smart contract invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add support for list address transactions.
 - Add support for exporting the private key of a `WalletAddress`
+- Add support for invoking Smart Contracts using MPC and Developer-managed Wallets.
 
 ## [0.2.0]
 

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -476,11 +476,11 @@ export interface ContractInvocation {
      */
     'method': string;
     /**
-     * The arguments to be passed to the contract method.
-     * @type {Array<string>}
+     * The JSON-encoded arguments to pass to the contract method. The keys should be the argument names and the values should be the argument values.
+     * @type {string}
      * @memberof ContractInvocation
      */
-    'args': Array<string>;
+    'args': string;
     /**
      * The JSON-encoded ABI of the contract.
      * @type {string}
@@ -569,11 +569,11 @@ export interface CreateContractInvocationRequest {
      */
     'method': string;
     /**
-     * The arguments to pass to the contract method.
-     * @type {Array<string>}
+     * The JSON-encoded arguments to pass to the contract method. The keys should be the argument names and the values should be the argument values.
+     * @type {string}
      * @memberof CreateContractInvocationRequest
      */
-    'args': Array<string>;
+    'args': string;
     /**
      * The JSON-encoded ABI of the contract.
      * @type {string}
@@ -1506,7 +1506,7 @@ export interface PayloadSignatureList {
      */
     'next_page': string;
     /**
-     * The total number of addresses for the wallet.
+     * The total number of payload signatures for the address.
      * @type {number}
      * @memberof PayloadSignatureList
      */

--- a/src/coinbase/address/wallet_address.ts
+++ b/src/coinbase/address/wallet_address.ts
@@ -79,7 +79,7 @@ export class WalletAddress extends Address {
   /**
    * Exports the Address's private key to a hex string.
    *
-   * @returns The Address's private key as a hex string. 
+   * @returns The Address's private key as a hex string.
    */
   public export() {
     if (this.key === undefined) {

--- a/src/coinbase/address/wallet_address.ts
+++ b/src/coinbase/address/wallet_address.ts
@@ -7,10 +7,12 @@ import { Coinbase } from "../coinbase";
 import { ArgumentError } from "../errors";
 import { Trade } from "../trade";
 import { Transfer } from "../transfer";
+import { ContractInvocation } from "../contract_invocation";
 import {
   Amount,
   CreateTransferOptions,
   CreateTradeOptions,
+  CreateContractInvocationOptions,
   Destination,
   StakeOptionsMode,
 } from "../types";
@@ -262,6 +264,66 @@ export class WalletAddress extends Address {
     await trade.broadcast();
 
     return trade;
+  }
+
+  /**
+   * Invokes a contract with the given data.
+   *
+   * @param options - The options to invoke the contract
+   * @param options.contractAddress - The address of the contract the method will be invoked on.
+   * @param options.method - The method to invoke on the contract.
+   * @param options.abi - The ABI of the contract.
+   * @param options.args - The arguments to pass to the contract method invocation.
+   *   The keys should be the argument names and the values should be the argument values.
+   * @returns The ContractInvocation object.
+   * @throws {APIError} if the API request to create a contract invocation fails.
+   */
+  public async invokeContract(
+    options: CreateContractInvocationOptions,
+  ): Promise<ContractInvocation> {
+    if (!Coinbase.useServerSigner && !this.key) {
+      throw new Error("Cannot invoke contract from address without private key loaded");
+    }
+
+    const contractInvocation = await this.createContractInvocation(options);
+
+    if (Coinbase.useServerSigner) {
+      return contractInvocation;
+    }
+
+    await contractInvocation.sign(this.getSigner());
+    await contractInvocation.broadcast();
+
+    return contractInvocation;
+  }
+
+  /**
+   * Creates a contract invocation model for the specified contract address, method, and arguments.
+   * The ABI object must be specified if the contract is not a known contract.
+   *
+   * @param amount - The amount of the Asset to send.
+   * @param fromAsset - The Asset to trade from.
+   * @param toAsset - The Asset to trade to.
+   * @returns A promise that resolves to a Trade object representing the new trade.
+   */
+  private async createContractInvocation({
+    abi,
+    args,
+    contractAddress,
+    method,
+  }: CreateContractInvocationOptions): Promise<ContractInvocation> {
+    const resp = await Coinbase.apiClients.contractInvocation!.createContractInvocation(
+      this.getWalletId(),
+      this.getId(),
+      {
+        method,
+        abi: JSON.stringify(abi),
+        contract_address: contractAddress,
+        args: JSON.stringify(args),
+      },
+    );
+
+    return ContractInvocation.fromModel(resp?.data);
   }
 
   /**

--- a/src/coinbase/coinbase.ts
+++ b/src/coinbase/coinbase.ts
@@ -15,6 +15,7 @@ import {
   WebhooksApiFactory,
   NetworkIdentifier,
   ContractEventsApiFactory,
+  ContractInvocationsApiFactory,
 } from "../client";
 import { BASE_PATH } from "./../client/base";
 import { Configuration } from "./../client/configuration";
@@ -128,6 +129,11 @@ export class Coinbase {
     Coinbase.apiClients.validator = ValidatorsApiFactory(config, basePath, axiosInstance);
     Coinbase.apiClients.asset = AssetsApiFactory(config, basePath, axiosInstance);
     Coinbase.apiClients.webhook = WebhooksApiFactory(config, basePath, axiosInstance);
+    Coinbase.apiClients.contractInvocation = ContractInvocationsApiFactory(
+      config,
+      basePath,
+      axiosInstance,
+    );
     Coinbase.apiClients.externalAddress = ExternalAddressesApiFactory(
       config,
       basePath,

--- a/src/coinbase/contract_invocation.ts
+++ b/src/coinbase/contract_invocation.ts
@@ -1,0 +1,257 @@
+import { TransactionStatus } from "./types";
+import { Transaction } from "./transaction";
+import { Coinbase } from "./coinbase";
+import { ContractInvocation as ContractInvocationModel } from "../client/api";
+import { ethers } from "ethers";
+import { delay } from "./utils";
+import { TimeoutError } from "./errors";
+
+/**
+ * A representation of a ContractInvocation, which moves an Amount of an Asset from
+ * a user-controlled Wallet to another Address. The fee is assumed to be paid
+ * in the native Asset of the Network.
+ */
+export class ContractInvocation {
+  private model: ContractInvocationModel;
+
+  /**
+   * Private constructor to prevent direct instantiation outside of the factory methods.
+   *
+   * @ignore
+   * @param contractInvocationModel - The ContractInvocation model.
+   * @hideconstructor
+   */
+  private constructor(contractInvocationModel: ContractInvocationModel) {
+    if (!contractInvocationModel) {
+      throw new Error("ContractInvocation model cannot be empty");
+    }
+    this.model = contractInvocationModel;
+  }
+
+  /**
+   * Converts a ContractInvocationModel into a ContractInvocation object.
+   *
+   * @param contractInvocationModel - The ContractInvocation model object.
+   * @returns The ContractInvocation object.
+   */
+  public static fromModel(contractInvocationModel: ContractInvocationModel): ContractInvocation {
+    return new ContractInvocation(contractInvocationModel);
+  }
+
+  /**
+   * Returns the ID of the ContractInvocation.
+   *
+   * @returns The ContractInvocation ID.
+   */
+  public getId(): string {
+    return this.model.contract_invocation_id;
+  }
+
+  /**
+   * Returns the Network ID of the ContractInvocation.
+   *
+   * @returns The Network ID.
+   */
+  public getNetworkId(): string {
+    return this.model.network_id;
+  }
+
+  /**
+   * Returns the Wallet ID of the ContractInvocation.
+   *
+   * @returns The Wallet ID.
+   */
+  public getWalletId(): string {
+    return this.model.wallet_id;
+  }
+
+  /**
+   * Returns the From Address ID of the ContractInvocation.
+   *
+   * @returns The From Address ID.
+   */
+  public getFromAddressId(): string {
+    return this.model.address_id;
+  }
+
+  /**
+   * Returns the Destination Address ID of the ContractInvocation.
+   *
+   * @returns The Destination Address ID.
+   */
+  public getContractAddressId(): string {
+    return this.model.contract_address;
+  }
+
+  /**
+   * Returns the Method of the ContractInvocation.
+   *
+   * @returns The Method.
+   */
+  public getMethod(): string {
+    return this.model.method;
+  }
+
+  /**
+   * Returns the Arguments of the ContractInvocation.
+   *
+   * @returns {object} The arguments object passed to the contract invocation.
+   * The key is the argument name and the value is the argument value.
+   */
+  public getArgs(): object {
+    return JSON.parse(this.model.args);
+  }
+
+  /**
+   * Returns the ABI of the ContractInvocation, if specified.
+   *
+   * @returns The ABI as an object, or undefined if not available.
+   */
+  public getAbi(): object | undefined {
+    if (!this.model.abi) return undefined;
+
+    return JSON.parse(this.model.abi);
+  }
+
+  /**
+   * Returns the Transaction Hash of the ContractInvocation.
+   *
+   * @returns The Transaction Hash as a Hex string, or undefined if not yet available.
+   */
+  public getTransactionHash(): string | undefined {
+    return this.getTransaction().getTransactionHash();
+  }
+
+  /**
+   * Returns the Transaction of the ContractInvocation.
+   *
+   * @returns The ethers.js Transaction object.
+   * @throws (InvalidUnsignedPayload) If the Unsigned Payload is invalid.
+   */
+  public getRawTransaction(): ethers.Transaction {
+    return this.getTransaction().rawTransaction();
+  }
+
+  /**
+   * Signs the ContractInvocation with the provided key and returns the hex signature
+   * required for broadcasting the ContractInvocation.
+   *
+   * @param key - The key to sign the ContractInvocation with
+   * @returns The hex-encoded signed payload
+   */
+  async sign(key: ethers.Wallet): Promise<string> {
+    return this.getTransaction().sign(key);
+  }
+
+  /**
+   * Returns the Status of the ContractInvocation.
+   *
+   * @returns The Status of the ContractInvocation.
+   */
+  public getStatus(): TransactionStatus | undefined {
+    return this.getTransaction().getStatus();
+  }
+
+  /**
+   * Returns the Transaction of the ContractInvocation.
+   *
+   * @returns The Transaction
+   */
+  public getTransaction(): Transaction {
+    return new Transaction(this.model.transaction);
+  }
+
+  /**
+   * Returns the link to the Transaction on the blockchain explorer.
+   *
+   * @returns The link to the Transaction on the blockchain explorer.
+   */
+  public getTransactionLink(): string {
+    return this.getTransaction().getTransactionLink();
+  }
+
+  /**
+   * Broadcasts the ContractInvocation to the Network.
+   *
+   * @returns The ContractInvocation object
+   * @throws {APIError} if the API request to broadcast a ContractInvocation fails.
+   */
+  public async broadcast(): Promise<ContractInvocation> {
+    if (!this.getTransaction()?.isSigned())
+      throw new Error("Cannot broadcast unsigned ContractInvocation");
+
+    const broadcastContractInvocationRequest = {
+      signed_payload: this.getTransaction()!.getSignature()!,
+    };
+
+    const response = await Coinbase.apiClients.contractInvocation!.broadcastContractInvocation(
+      this.getWalletId(),
+      this.getFromAddressId(),
+      this.getId(),
+      broadcastContractInvocationRequest,
+    );
+
+    return ContractInvocation.fromModel(response.data);
+  }
+
+  /**
+   * Waits for the ContractInvocation to be confirmed on the Network or fail on chain.
+   * Waits until the ContractInvocation is completed or failed on-chain by polling at the given interval.
+   * Raises an error if the ContractInvocation takes longer than the given timeout.
+   *
+   * @param options - The options to configure the wait function.
+   * @param options.intervalSeconds - The interval to check the status of the ContractInvocation.
+   * @param options.timeoutSeconds - The maximum time to wait for the ContractInvocation to be confirmed.
+   *
+   * @returns The ContractInvocation object in a terminal state.
+   * @throws {Error} if the ContractInvocation times out.
+   */
+  public async wait({
+    intervalSeconds = 0.2,
+    timeoutSeconds = 10,
+  } = {}): Promise<ContractInvocation> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutSeconds * 1000) {
+      await this.reload();
+
+      // If the ContractInvocation is in a terminal state, return the ContractInvocation.
+      const status = this.getStatus();
+      if (status === TransactionStatus.COMPLETE || status === TransactionStatus.FAILED) {
+        return this;
+      }
+
+      await delay(intervalSeconds);
+    }
+
+    throw new TimeoutError("ContractInvocation timed out");
+  }
+
+  /**
+   * Reloads the ContractInvocation model with the latest data from the server.
+   *
+   * @throws {APIError} if the API request to get a ContractInvocation fails.
+   */
+  public async reload(): Promise<void> {
+    const result = await Coinbase.apiClients.contractInvocation!.getContractInvocation(
+      this.getWalletId(),
+      this.getFromAddressId(),
+      this.getId(),
+    );
+    this.model = result?.data;
+  }
+
+  /**
+   * Returns a string representation of the ContractInvocation.
+   *
+   * @returns The string representation of the ContractInvocation.
+   */
+  public toString(): string {
+    return (
+      `ContractInvocation{contractInvocationId: '${this.getId()}', networkId: '${this.getNetworkId()}', ` +
+      `fromAddressId: '${this.getFromAddressId()}', contractAddressId: '${this.getContractAddressId()}', ` +
+      `method: '${this.getMethod()}', args: '${this.getArgs()}', transactionHash: '${this.getTransactionHash()}', ` +
+      `transactionLink: '${this.getTransactionLink()}', status: '${this.getStatus()}'}`
+    );
+  }
+}

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -45,6 +45,10 @@ import {
   WebhookEventType,
   WebhookEventFilter,
   AddressTransactionList,
+  BroadcastContractInvocationRequest,
+  CreateContractInvocationRequest,
+  ContractInvocationList,
+  ContractInvocation as ContractInvocationModel,
 } from "./../client/api";
 import { Address } from "./address";
 import { Wallet } from "./wallet";
@@ -754,6 +758,7 @@ export type ApiClients = {
   externalAddress?: ExternalAddressAPIClient;
   webhook?: WebhookApiClient;
   smartContract?: ExternalSmartContractAPIClient;
+  contractInvocation?: ContractInvocationAPIClient;
 };
 
 /**
@@ -948,8 +953,6 @@ export type CreateTransferOptions = {
   amount: Amount;
   assetId: string;
   destination: Destination;
-  timeoutSeconds?: number;
-  intervalSeconds?: number;
   gasless?: boolean;
 };
 
@@ -960,8 +963,16 @@ export type CreateTradeOptions = {
   amount: Amount;
   fromAssetId: string;
   toAssetId: string;
-  timeoutSeconds?: number;
-  intervalSeconds?: number;
+};
+
+/**
+ * Options for creating a Contract Invocation.
+ */
+export type CreateContractInvocationOptions = {
+  contractAddress: string;
+  abi?: object;
+  method: string;
+  args: object;
 };
 
 /**
@@ -1106,4 +1117,81 @@ export type CreateWebhookOptions = {
   eventType: WebhookEventType;
   eventFilters?: Array<WebhookEventFilter>;
   signatureHeader?: string;
+};
+
+/**
+ * ContractInvocationAPI client type definition.
+ */
+export type ContractInvocationAPIClient = {
+  /**
+   * Broadcasts a contract invocation.
+   *
+   * @param walletId - The ID of the wallet the address belongs to.
+   * @param addressId - The ID of the address the contract invocation belongs to.
+   * @param contractInvocationId - The ID of the contract invocation to broadcast.
+   * @param broadcastContractInvocationRequest - The request body.
+   * @param options - Axios request options.
+   * @returns - A promise resolving to the ContractInvocation model.
+   * @throws {APIError} If the request fails.
+   */
+  broadcastContractInvocation(
+    walletId: string,
+    addressId: string,
+    contractInvocationId: string,
+    broadcastContractInvocationRequest: BroadcastContractInvocationRequest,
+    options?: AxiosRequestConfig,
+  ): AxiosPromise<ContractInvocationModel>;
+
+  /**
+   * Creates a Contract Invocation.
+   *
+   * @param walletId - The ID of the wallet the address belongs to.
+   * @param addressId - The ID of the address the contract invocation belongs to.
+   * @param createContractInvocationRequest - The request body.
+   * @param options - Axios request options.
+   * @returns - A promise resolving to the ContractInvocation model.
+   * @throws {APIError} If the request fails.
+   */
+  createContractInvocation(
+    walletId: string,
+    addressId: string,
+    createContractInvocationRequest: CreateContractInvocationRequest,
+    options?: AxiosRequestConfig,
+  ): AxiosPromise<ContractInvocationModel>;
+
+  /**
+   * Retrieves a Contract Invocation.
+   *
+   * @param walletId - The ID of the wallet the address belongs to.
+   * @param addressId - The ID of the address the contract invocation belongs to.
+   * @param contractInvocationId - The ID of the contract invocation to retrieve.
+   * @param options - Axios request options.
+   * @returns - A promise resolving to the ContractInvocation model.
+   * @throws {APIError} If the request fails.
+   */
+  getContractInvocation(
+    walletId: string,
+    addressId: string,
+    contractInvocationId: string,
+    options?: AxiosRequestConfig,
+  ): AxiosPromise<ContractInvocationModel>;
+
+  /**
+   * Lists Contract Invocations.
+   *
+   * @param walletId - The ID of the wallet the address belongs to.
+   * @param addressId - The ID of the address the contract invocations belong to.
+   * @param limit - The maximum number of contract invocations to return.
+   * @param page - The cursor for pagination across multiple pages of contract invocations.
+   * @param options - Axios request options.
+   * @returns - A promise resolving to the ContractInvocation list.
+   * @throws {APIError} If the request fails.
+   */
+  listContractInvocations(
+    walletId: string,
+    addressId: string,
+    limit?: number,
+    page?: string,
+    options?: AxiosRequestConfig,
+  ): AxiosPromise<ContractInvocationList>;
 };

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -17,6 +17,7 @@ import { Trade } from "./trade";
 import { Transfer } from "./transfer";
 import {
   Amount,
+  CreateContractInvocationOptions,
   CreateTransferOptions,
   CreateTradeOptions,
   ListHistoricalBalancesOptions,
@@ -32,6 +33,7 @@ import { StakingOperation } from "./staking_operation";
 import { StakingReward } from "./staking_reward";
 import { StakingBalance } from "./staking_balance";
 import { PayloadSignature } from "./payload_signature";
+import { ContractInvocation } from "../coinbase/contract_invocation";
 
 /**
  * A representation of a Wallet. Wallets come with a single default Address, but can expand to have a set of Addresses,
@@ -770,6 +772,28 @@ export class Wallet {
     }
 
     return await this.getDefaultAddress()!.createPayloadSignature(unsignedPayload);
+  }
+
+  /**
+   * Invokes a contract with the given data.
+   *
+   * @param options - The options to invoke the contract
+   * @param options.contractAddress - The address of the contract the method will be invoked on.
+   * @param options.method - The method to invoke on the contract.
+   * @param options.abi - The ABI of the contract.
+   * @param options.args - The arguments to pass to the contract method invocation.
+   *   The keys should be the argument names and the values should be the argument values.
+   * @returns The ContractInvocation object.
+   * @throws {APIError} if the API request to create a contract invocation fails.
+   */
+  public async invokeContract(
+    options: CreateContractInvocationOptions,
+  ): Promise<ContractInvocation> {
+    if (!this.getDefaultAddress()) {
+      throw new Error("Default address not found");
+    }
+
+    return await this.getDefaultAddress()!.invokeContract(options);
   }
 
   /**

--- a/src/tests/address_test.ts
+++ b/src/tests/address_test.ts
@@ -46,7 +46,7 @@ describe("Address", () => {
             block_hash: "0x0dadd465fb063ceb78babbb30abbc6bfc0730d0c57a53e8f6dc778dafcea568f",
             block_height: "12345",
             unsigned_payload: "",
-            status: TransactionStatus.COMPLETE
+            status: TransactionStatus.COMPLETE,
           },
           {
             network_id: "base-sepolia",
@@ -54,28 +54,23 @@ describe("Address", () => {
             block_hash: "block_hash",
             block_height: "12348",
             unsigned_payload: "",
-            status: TransactionStatus.FAILED
-          }
+            status: TransactionStatus.FAILED,
+          },
         ],
         has_more: true,
         next_page: "pageToken",
       };
       Coinbase.apiClients.externalAddress = externalAddressApiMock;
-      Coinbase.apiClients.externalAddress!.listAddressTransactions = mockReturnValue(
-        mockTransactionsResponse,
-      );
+      Coinbase.apiClients.externalAddress!.listAddressTransactions =
+        mockReturnValue(mockTransactionsResponse);
     });
 
     it("should return results with param", async () => {
-      const result = await address.listTransactions({limit: 2, page: "page"});
+      const result = await address.listTransactions({ limit: 2, page: "page" });
       expect(result.transactions.length).toEqual(2);
       expect(result.transactions[0].blockHeight()).toEqual("12345");
-      expect(
-        Coinbase.apiClients.externalAddress!.listAddressTransactions,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        Coinbase.apiClients.externalAddress!.listAddressTransactions,
-      ).toHaveBeenCalledWith(
+      expect(Coinbase.apiClients.externalAddress!.listAddressTransactions).toHaveBeenCalledTimes(1);
+      expect(Coinbase.apiClients.externalAddress!.listAddressTransactions).toHaveBeenCalledWith(
         address.getNetworkId(),
         address.getId(),
         2,
@@ -93,8 +88,8 @@ describe("Address", () => {
             block_hash: "block_hash",
             block_height: "12348",
             unsigned_payload: "",
-            status: TransactionStatus.COMPLETE
-          }
+            status: TransactionStatus.COMPLETE,
+          },
         ],
         has_more: false,
         next_page: "",
@@ -102,12 +97,8 @@ describe("Address", () => {
       const result = await address.listTransactions({});
       expect(result.transactions.length).toEqual(1);
       expect(result.transactions[0].blockHeight()).toEqual("12348");
-      expect(
-        Coinbase.apiClients.externalAddress!.listAddressTransactions,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        Coinbase.apiClients.externalAddress!.listAddressTransactions,
-      ).toHaveBeenCalledWith(
+      expect(Coinbase.apiClients.externalAddress!.listAddressTransactions).toHaveBeenCalledTimes(1);
+      expect(Coinbase.apiClients.externalAddress!.listAddressTransactions).toHaveBeenCalledWith(
         address.getNetworkId(),
         address.getId(),
         undefined,
@@ -124,12 +115,8 @@ describe("Address", () => {
       });
       const result = await address.listTransactions({});
       expect(result.transactions.length).toEqual(0);
-      expect(
-        Coinbase.apiClients.externalAddress!.listAddressTransactions,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        Coinbase.apiClients.externalAddress!.listAddressTransactions,
-      ).toHaveBeenCalledWith(
+      expect(Coinbase.apiClients.externalAddress!.listAddressTransactions).toHaveBeenCalledTimes(1);
+      expect(Coinbase.apiClients.externalAddress!.listAddressTransactions).toHaveBeenCalledWith(
         address.getNetworkId(),
         address.getId(),
         undefined,

--- a/src/tests/contract_invocation_test.ts
+++ b/src/tests/contract_invocation_test.ts
@@ -1,0 +1,391 @@
+import { ethers } from "ethers";
+import { AxiosError } from "axios";
+import { Decimal } from "decimal.js";
+import {
+  ContractInvocation as ContractInvocationModel,
+  TransactionStatusEnum,
+} from "../client/api";
+import { TransactionStatus } from "../coinbase/types";
+import { ContractInvocation } from "../coinbase/contract_invocation";
+import { Transaction } from "../coinbase/transaction";
+import { Coinbase } from "../coinbase/coinbase";
+import {
+  VALID_CONTRACT_INVOCATION_MODEL,
+  VALID_SIGNED_CONTRACT_INVOCATION_MODEL,
+  mockReturnValue,
+  mockReturnRejectedValue,
+  contractInvocationApiMock,
+  MINT_NFT_ARGS,
+  MINT_NFT_ABI,
+} from "./utils";
+
+import { TimeoutError } from "../coinbase/errors";
+import { APIError } from "../coinbase/api_error";
+
+describe("Contract Invocation Class", () => {
+  let contractInvocationModel: ContractInvocationModel;
+  let contractInvocation: ContractInvocation;
+
+  beforeEach(() => {
+    Coinbase.apiClients.contractInvocation = contractInvocationApiMock;
+
+    contractInvocationModel = VALID_CONTRACT_INVOCATION_MODEL;
+    contractInvocation = ContractInvocation.fromModel(contractInvocationModel);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("initializes a new ContractInvocation", () => {
+      expect(contractInvocation).toBeInstanceOf(ContractInvocation);
+    });
+
+    it("raises an error when the contractInvocation model is empty", () => {
+      expect(() => ContractInvocation.fromModel(undefined!)).toThrow(
+        "ContractInvocation model cannot be empty",
+      );
+    });
+  });
+
+  describe("#getId", () => {
+    it("returns the contract invocation ID", () => {
+      expect(contractInvocation.getId()).toEqual(
+        VALID_CONTRACT_INVOCATION_MODEL.contract_invocation_id,
+      );
+    });
+  });
+
+  describe("#getNetworkId", () => {
+    it("returns the network ID", () => {
+      expect(contractInvocation.getNetworkId()).toEqual(VALID_CONTRACT_INVOCATION_MODEL.network_id);
+    });
+  });
+
+  describe("#getWalletId", () => {
+    it("returns the wallet ID", () => {
+      expect(contractInvocation.getWalletId()).toEqual(VALID_CONTRACT_INVOCATION_MODEL.wallet_id);
+    });
+  });
+
+  describe("#getFromAddressId", () => {
+    it("returns the source address ID", () => {
+      expect(contractInvocation.getFromAddressId()).toEqual(
+        VALID_CONTRACT_INVOCATION_MODEL.address_id,
+      );
+    });
+  });
+
+  describe("#getContractAddressId", () => {
+    it("returns the contract address ID", () => {
+      expect(contractInvocation.getContractAddressId()).toEqual(
+        VALID_CONTRACT_INVOCATION_MODEL.contract_address,
+      );
+    });
+  });
+
+  describe("#getMethod", () => {
+    it("return the conrtact invocation's method", () => {
+      expect(contractInvocation.getMethod()).toEqual(VALID_CONTRACT_INVOCATION_MODEL.method);
+    });
+  });
+
+  describe("#getArgs", () => {
+    it("returns the parsed arguments", () => {
+      expect(contractInvocation.getArgs()).toEqual(MINT_NFT_ARGS);
+    });
+  });
+
+  describe("#getAbi", () => {
+    it("returns the parsed ABI", () => {
+      expect(contractInvocation.getAbi()).toEqual(MINT_NFT_ABI);
+    });
+  });
+
+  describe("#getTransactionHash", () => {
+    describe("when the transaction has a hash", () => {
+      let transactionHash = "0xtransactionHash";
+
+      beforeEach(() => {
+        contractInvocation = ContractInvocation.fromModel({
+          ...VALID_CONTRACT_INVOCATION_MODEL,
+          transaction: {
+            ...VALID_CONTRACT_INVOCATION_MODEL.transaction!,
+            transaction_hash: transactionHash,
+          },
+        });
+      });
+
+      it("returns the transaction hash", () => {
+        expect(contractInvocation.getTransactionHash()).toEqual(transactionHash);
+      });
+    });
+
+    describe("when the transaction does not have a hash", () => {
+      it("returns undefined", () => {
+        expect(contractInvocation.getTransactionHash()).toBeUndefined();
+      });
+    });
+  });
+
+  describe("#getTransactionLink", () => {
+    describe("when the transaction has a transaction link", () => {
+      let transactionLink = `https://sepolia.basescan.org/tx/0xtransactionHash`;
+
+      beforeEach(() => {
+        contractInvocation = ContractInvocation.fromModel({
+          ...VALID_CONTRACT_INVOCATION_MODEL,
+          transaction: {
+            ...VALID_CONTRACT_INVOCATION_MODEL.transaction!,
+            transaction_link: transactionLink,
+          },
+        });
+      });
+
+      it("returns the transaction link", () => {
+        expect(contractInvocation.getTransactionLink()).toEqual(transactionLink);
+      });
+    });
+
+    describe("when the transaction does not have a link", () => {
+      it("returns undefined", () => {
+        expect(contractInvocation.getTransactionLink()).toBeUndefined();
+      });
+    });
+  });
+
+  describe("#getTransaction", () => {
+    it("returns the transaction", () => {
+      expect(contractInvocation.getTransaction()).toBeInstanceOf(Transaction);
+    });
+  });
+
+  describe("#getRawTransaction", () => {
+    it("returns the ContractInvocation raw transaction", () => {
+      expect(contractInvocation.getRawTransaction()).toBeInstanceOf(ethers.Transaction);
+    });
+  });
+
+  describe("#getStatus", () => {
+    let txStatus;
+
+    beforeEach(() => {
+      contractInvocationModel = {
+        ...VALID_CONTRACT_INVOCATION_MODEL,
+        transaction: {
+          ...VALID_CONTRACT_INVOCATION_MODEL.transaction!,
+          status: txStatus,
+        },
+      };
+
+      contractInvocation = ContractInvocation.fromModel(contractInvocationModel);
+    });
+
+    [
+      TransactionStatus.PENDING,
+      TransactionStatus.BROADCAST,
+      TransactionStatus.COMPLETE,
+      TransactionStatus.FAILED,
+    ].forEach(status => {
+      describe(`when the transaction has status ${status}`, () => {
+        beforeAll(() => (txStatus = status));
+        afterAll(() => (txStatus = undefined));
+
+        it("returns the correct status", async () => {
+          expect(contractInvocation.getStatus()).toEqual(status);
+        });
+      });
+    });
+  });
+
+  describe("#broadcast", () => {
+    let signedPayload = "0xsignedHash";
+
+    beforeEach(() => {
+      // Ensure signed payload is present.
+      contractInvocation = ContractInvocation.fromModel({
+        ...VALID_CONTRACT_INVOCATION_MODEL,
+        transaction: {
+          ...VALID_CONTRACT_INVOCATION_MODEL.transaction!,
+          signed_payload: signedPayload,
+        },
+      });
+    });
+
+    describe("when it was successful", () => {
+      let broadcastedInvocation;
+
+      beforeEach(async () => {
+        Coinbase.apiClients.contractInvocation!.broadcastContractInvocation = mockReturnValue({
+          ...VALID_CONTRACT_INVOCATION_MODEL,
+          transaction: {
+            ...VALID_CONTRACT_INVOCATION_MODEL.transaction!,
+            signed_payload: signedPayload,
+            status: TransactionStatus.BROADCAST,
+          },
+        });
+
+        broadcastedInvocation = await contractInvocation.broadcast();
+      });
+
+      it("returns the broadcasted contract invocation", async () => {
+        expect(broadcastedInvocation).toBeInstanceOf(ContractInvocation);
+        expect(broadcastedInvocation.getStatus()).toEqual(TransactionStatus.BROADCAST);
+      });
+
+      it("broadcasts the contract invocation", async () => {
+        expect(
+          Coinbase.apiClients.contractInvocation!.broadcastContractInvocation,
+        ).toHaveBeenCalledWith(
+          contractInvocation.getWalletId(),
+          contractInvocation.getFromAddressId(),
+          contractInvocation.getId(),
+          {
+            signed_payload: signedPayload.slice(2),
+          },
+        );
+
+        expect(
+          Coinbase.apiClients.contractInvocation!.broadcastContractInvocation,
+        ).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("when the transaction is not signed", () => {
+      beforeEach(() => {
+        contractInvocation = ContractInvocation.fromModel(VALID_CONTRACT_INVOCATION_MODEL);
+      });
+
+      it("throws an error", async () => {
+        expect(contractInvocation.broadcast()).rejects.toThrow(
+          "Cannot broadcast unsigned ContractInvocation",
+        );
+      });
+    });
+
+    describe("when broadcasting fails", () => {
+      beforeEach(() => {
+        Coinbase.apiClients.contractInvocation!.broadcastContractInvocation =
+          mockReturnRejectedValue(
+            new APIError({
+              response: {
+                status: 400,
+                data: {
+                  code: "invalid_signed_payload",
+                  message: "failed to broadcast contract invocation: invalid signed payload",
+                },
+              },
+            } as AxiosError),
+          );
+      });
+
+      it("throws an error", async () => {
+        expect(contractInvocation.broadcast()).rejects.toThrow(APIError);
+      });
+    });
+  });
+
+  describe("#sign", () => {
+    let signingKey: any = ethers.Wallet.createRandom();
+
+    it("return the signature", async () => {
+      const contractInvocation = ContractInvocation.fromModel({
+        ...VALID_CONTRACT_INVOCATION_MODEL,
+        transaction: {
+          ...VALID_CONTRACT_INVOCATION_MODEL.transaction!,
+          signed_payload: "0xsignedHash",
+        },
+      });
+
+      const signature = await contractInvocation.sign(signingKey);
+
+      expect(signature).toEqual(contractInvocation.getTransaction()!.getSignature()!);
+    });
+  });
+
+  describe("#wait", () => {
+    describe("when the transaction is complete", () => {
+      beforeEach(() => {
+        Coinbase.apiClients.contractInvocation!.getContractInvocation = mockReturnValue({
+          ...VALID_CONTRACT_INVOCATION_MODEL,
+          transaction: {
+            ...VALID_CONTRACT_INVOCATION_MODEL.transaction!,
+            status: TransactionStatusEnum.Complete,
+          },
+        });
+      });
+
+      it("successfully waits and returns", async () => {
+        const completedContractInvocation = await contractInvocation.wait();
+        expect(completedContractInvocation).toBeInstanceOf(ContractInvocation);
+        expect(completedContractInvocation.getStatus()).toEqual(TransactionStatus.COMPLETE);
+      });
+    });
+
+    describe("when the transaction is failed", () => {
+      beforeEach(() => {
+        Coinbase.apiClients.contractInvocation!.getContractInvocation = mockReturnValue({
+          ...VALID_CONTRACT_INVOCATION_MODEL,
+          transaction: {
+            ...VALID_CONTRACT_INVOCATION_MODEL.transaction!,
+            status: TransactionStatusEnum.Failed,
+          },
+          status: TransactionStatus.FAILED,
+        });
+      });
+
+      it("successfully waits and returns a failed invocation", async () => {
+        const completedContractInvocation = await contractInvocation.wait();
+        expect(completedContractInvocation).toBeInstanceOf(ContractInvocation);
+        expect(completedContractInvocation.getStatus()).toEqual(TransactionStatus.FAILED);
+      });
+    });
+
+    describe("when the transaction is pending", () => {
+      beforeEach(() => {
+        Coinbase.apiClients.contractInvocation!.getContractInvocation = mockReturnValue({
+          ...VALID_CONTRACT_INVOCATION_MODEL,
+          transaction: {
+            ...VALID_CONTRACT_INVOCATION_MODEL.transaction!,
+            status: TransactionStatusEnum.Pending,
+          },
+        });
+      });
+
+      it("throws a timeout error", async () => {
+        expect(
+          contractInvocation.wait({ timeoutSeconds: 0.05, intervalSeconds: 0.05 }),
+        ).rejects.toThrow(new TimeoutError("ContractInvocation timed out"));
+      });
+    });
+  });
+
+  describe("#reload", () => {
+    it("returns the updated contract invocation", async () => {
+      Coinbase.apiClients.contractInvocation!.getContractInvocation = mockReturnValue({
+        ...VALID_CONTRACT_INVOCATION_MODEL,
+        transaction: {
+          ...VALID_CONTRACT_INVOCATION_MODEL.transaction!,
+          status: TransactionStatusEnum.Complete,
+        },
+      });
+      await contractInvocation.reload();
+      expect(contractInvocation.getStatus()).toEqual(TransactionStatus.COMPLETE);
+      expect(Coinbase.apiClients.contractInvocation!.getContractInvocation).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+  });
+
+  describe("#toString", () => {
+    it("returns the same value as toString", () => {
+      expect(contractInvocation.toString()).toEqual(
+        `ContractInvocation{contractInvocationId: '${contractInvocation.getId()}', networkId: '${contractInvocation.getNetworkId()}', ` +
+          `fromAddressId: '${contractInvocation.getFromAddressId()}', contractAddressId: '${contractInvocation.getContractAddressId()}', ` +
+          `method: '${contractInvocation.getMethod()}', args: '${contractInvocation.getArgs()}', transactionHash: '${contractInvocation.getTransactionHash()}', ` +
+          `transactionLink: '${contractInvocation.getTransactionLink()}', status: '${contractInvocation.getStatus()!}'}`,
+      );
+    });
+  });
+});

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -105,14 +105,18 @@ describe("Coinbase SDK E2E Test", () => {
     console.log(`Second address balances: ${secondBalance}`);
 
     console.log("Fetching address transactions...");
-    const result = await unhydratedWallet.getDefaultAddress()?.listTransactions( {limit: 1} );
+    const result = await unhydratedWallet.getDefaultAddress()?.listTransactions({ limit: 1 });
     expect(result?.transactions.length).toBeGreaterThan(0);
     console.log(`Fetched transactions: ${result?.transactions[0].toString()}`);
 
     console.log("Fetching address historical balances...");
-    const balance_result = await unhydratedWallet.getDefaultAddress()?.listHistoricalBalances( {assetId: Coinbase.assets.Eth, limit: 2} );
+    const balance_result = await unhydratedWallet
+      .getDefaultAddress()
+      ?.listHistoricalBalances({ assetId: Coinbase.assets.Eth, limit: 2 });
     expect(balance_result?.historicalBalances.length).toBeGreaterThan(0);
-    console.log(`First eth historical balance: ${balance_result?.historicalBalances[0].amount.toString()}`);
+    console.log(
+      `First eth historical balance: ${balance_result?.historicalBalances[0].amount.toString()}`,
+    );
 
     const savedSeed = JSON.parse(fs.readFileSync("test_seed.json", "utf-8"));
     fs.unlinkSync("test_seed.json");

--- a/src/tests/transaction_test.ts
+++ b/src/tests/transaction_test.ts
@@ -1,4 +1,3 @@
-
 import { ethers } from "ethers";
 import { Transaction as TransactionModel, EthereumTransaction } from "../client/api";
 import { Transaction } from "./../coinbase/transaction";
@@ -39,10 +38,10 @@ describe("Transaction", () => {
 
     transactionHash = "0x6c087c1676e8269dd81e0777244584d0cbfd39b6997b3477242a008fa9349e11";
 
-    blockHash = "0x0728750d458976fd010a2e15cef69ec71c6fccb3377f38a71b70ab551ab22688"
-    blockHeight = "18779006"
+    blockHash = "0x0728750d458976fd010a2e15cef69ec71c6fccb3377f38a71b70ab551ab22688";
+    blockHeight = "18779006";
     ethereumContent = {
-      priority_fee_per_gas: 1000
+      priority_fee_per_gas: 1000,
     } as EthereumTransaction;
 
     model = {
@@ -61,12 +60,12 @@ describe("Transaction", () => {
     } as TransactionModel;
 
     onchainModel = {
-        status: "complete",
-        from_address_id: fromAddressId,
-        unsigned_payload: "",
-        block_hash: blockHash,
-        block_height: blockHeight,
-        content: ethereumContent,
+      status: "complete",
+      from_address_id: fromAddressId,
+      unsigned_payload: "",
+      block_hash: blockHash,
+      block_height: blockHeight,
+      content: ethereumContent,
     } as TransactionModel;
 
     transaction = new Transaction(model);

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -14,6 +14,7 @@ import {
   PayloadSignature as PayloadSignatureModel,
   PayloadSignatureList,
   PayloadSignatureStatusEnum,
+  ContractInvocation as ContractInvocationModel,
   ValidatorList,
   Validator,
   StakingOperationStatusEnum,
@@ -228,6 +229,48 @@ export const VALID_PAYLOAD_SIGNATURE_LIST: PayloadSignatureList = {
   has_more: false,
   next_page: "",
   total_count: 4,
+};
+
+export const MINT_NFT_ABI = [
+  {
+    inputs: [{ internalType: "address", name: "recipient", type: "address" }],
+    name: "mint",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "payable",
+    type: "function",
+  },
+];
+
+export const MINT_NFT_ARGS = { recipient: "0x475d41de7A81298Ba263184996800CBcaAD73C0b" };
+
+export const VALID_CONTRACT_INVOCATION_MODEL: ContractInvocationModel = {
+  wallet_id: walletId,
+  address_id: ethers.Wallet.createRandom().address,
+  contract_invocation_id: "test-contract-invocation-1",
+  network_id: Coinbase.networks.BaseSepolia,
+  contract_address: "0xcontract-address",
+  method: "mint",
+  args: JSON.stringify(MINT_NFT_ARGS),
+  abi: JSON.stringify(MINT_NFT_ABI),
+  transaction: {
+    network_id: Coinbase.networks.BaseSepolia,
+    from_address_id: "0xdeadbeef",
+    unsigned_payload:
+      "7b2274797065223a22307832222c22636861696e4964223a2230783134613334222c226e6f6e6365223a22307830222c22746f223a22307861383261623835303466646562326461646161336234663037356539363762626533353036356239222c22676173223a22307865623338222c226761735072696365223a6e756c6c2c226d61785072696f72697479466565506572476173223a2230786634323430222c226d6178466565506572476173223a2230786634333638222c2276616c7565223a22307830222c22696e707574223a223078366136323738343230303030303030303030303030303030303030303030303034373564343164653761383132393862613236333138343939363830306362636161643733633062222c226163636573734c697374223a5b5d2c2276223a22307830222c2272223a22307830222c2273223a22307830222c2279506172697479223a22307830222c2268617368223a22307865333131636632303063643237326639313566656433323165663065376431653965353362393761346166623737336638653935646431343630653665326163227d",
+    status: TransactionStatusEnum.Pending,
+  },
+};
+
+export const VALID_SIGNED_CONTRACT_INVOCATION_MODEL: ContractInvocationModel = {
+  ...VALID_CONTRACT_INVOCATION_MODEL,
+  transaction: {
+    ...VALID_CONTRACT_INVOCATION_MODEL.transaction,
+    signed_payload:
+      "02f88f83014a3480830f4240830f436882eb3894a82ab8504fdeb2dadaa3b4f075e967bbe35065b980a46a627842000000000000000000000000475d41de7a81298ba263184996800cbcaad73c0bc080a00bca053345d88d7cc02c257c5d74f8285bc6408c9020e1b4331779995f355c0ca04a8ec5bee1609d97f3ccba1e0d535441cf61c708e9bc632fe9963b34f97d0462",
+    status: TransactionStatusEnum.Broadcast,
+    transaction_hash: "0xdummy-transaction-hash",
+    transaction_link: "https://sepolia.basescan.org/tx/0xdummy-transaction-hash",
+  },
 };
 
 /**
@@ -512,4 +555,11 @@ export const serverSignersApiMock = {
 
 export const smartContractApiMock = {
   listContractEvents: jest.fn(),
+};
+
+export const contractInvocationApiMock = {
+  getContractInvocation: jest.fn(),
+  listContractInvocations: jest.fn(),
+  createContractInvocation: jest.fn(),
+  broadcastContractInvocation: jest.fn(),
 };

--- a/src/tests/wallet_address_test.ts
+++ b/src/tests/wallet_address_test.ts
@@ -293,7 +293,7 @@ describe("WalletAddress", () => {
 
     it("should not get the private key if not set", () => {
       const newAddress = new WalletAddress(VALID_ADDRESS_MODEL, undefined);
-      expect(() => { 
+      expect(() => {
         newAddress.export();
       }).toThrow(Error);
     });

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -506,7 +506,7 @@ describe("Wallet Class", () => {
   });
 
   describe(".createTransfer", () => {
-    let weiAmount, destination, intervalSeconds, timeoutSeconds;
+    let weiAmount, destination;
     let balanceModel: BalanceModel;
 
     beforeEach(() => {
@@ -514,8 +514,6 @@ describe("Wallet Class", () => {
       const key = ethers.Wallet.createRandom();
       weiAmount = new Decimal("5");
       destination = new WalletAddress(VALID_ADDRESS_MODEL, key as unknown as ethers.Wallet);
-      intervalSeconds = 0.2;
-      timeoutSeconds = 10;
       Coinbase.apiClients.externalAddress = externalAddressApiMock;
       Coinbase.apiClients.asset = assetsApiMock;
       Coinbase.apiClients.asset!.getAsset = getAssetMock();
@@ -568,8 +566,6 @@ describe("Wallet Class", () => {
           amount: weiAmount,
           assetId: Coinbase.assets.Wei,
           destination,
-          timeoutSeconds,
-          intervalSeconds,
         }),
       ).rejects.toThrow(APIError);
     });
@@ -584,8 +580,6 @@ describe("Wallet Class", () => {
           amount: weiAmount,
           assetId: Coinbase.assets.Wei,
           destination,
-          timeoutSeconds,
-          intervalSeconds,
         }),
       ).rejects.toThrow(APIError);
     });
@@ -597,8 +591,6 @@ describe("Wallet Class", () => {
           amount: insufficientAmount,
           assetId: Coinbase.assets.Wei,
           destination,
-          timeoutSeconds,
-          intervalSeconds,
         }),
       ).rejects.toThrow(ArgumentError);
     });
@@ -611,8 +603,6 @@ describe("Wallet Class", () => {
         amount: weiAmount,
         assetId: Coinbase.assets.Wei,
         destination,
-        timeoutSeconds,
-        intervalSeconds,
       });
 
       expect(Coinbase.apiClients.transfer!.createTransfer).toHaveBeenCalledTimes(1);

--- a/src/tests/webhook_test.ts
+++ b/src/tests/webhook_test.ts
@@ -165,13 +165,15 @@ describe("Webhook", () => {
     });
 
     it("should throw an error if creation fails", async () => {
-      Coinbase.apiClients.webhook!.createWebhook = jest.fn().mockRejectedValue(new Error("Failed to create webhook"));
+      Coinbase.apiClients.webhook!.createWebhook = jest
+        .fn()
+        .mockRejectedValue(new Error("Failed to create webhook"));
       await expect(
         Webhook.create({
           networkId: "test-network",
           notificationUri: "https://example.com/callback",
           eventType: "erc20_transfer",
-        })
+        }),
       ).rejects.toThrow("Failed to create webhook");
     });
   });


### PR DESCRIPTION
### What changed? Why?
This adds support for invoking a smart contract using MPC Wallets and developer-managed wallets.

### Example of how to invoke a smart contract:
```
const wallet = await Wallet.create();

await wallet.faucet();

const abi = [
  {
    inputs: [{internalType: 'address', name: 'recipient', type: 'address'}],
    name: 'mint',
    outputs: [{internalType: 'uint256', name: '', type: 'uint256'}],
    stateMutability: 'payable',
    type: 'function'
  }
]

const contractInvocation = await wallet.getDefaultAddress.invokeContract({
  abi,
  method: "mint",
  contractAddress: '0xa82aB8504fDeb2dADAa3B4F075E967BbE35065b9',
  args: ['0x475d41de7A81298Ba263184996800CBcaAD73C0b']
});

await contractInvocation.wait();
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->

* This is a new feature 
* This removes some unused parameters from creating transfer function options/typing.
  * This could cause errors in clients who are passing these functions. Note: The timeout/interval values are not being used in those method calls, so it is helpful for this to now error otherwise developers may be confused when changing those values does not do anything.