### PR TITLE
Update getDefaultAddress and getAddress to fetch addresses if not loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Changed
-- `getDefaultAddress` wallet method signature now returns a promise, and `getAddress` returns `WalletAddress` instead of `Address`. Both functions will now fetch addresses for the wallet if they haven't been loaded.
+- `getDefaultAddress` wallet method updated to return a promise, and `getAddress` wallet methods now return a promise and `WalletAddress` instead of `Address`. Both functions will now fetch addresses for the wallet if they haven't been loaded.
 
 ## [0.3.0] - 2024-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- `getDefaultAddress` wallet method signature now returns a promise, and `getAddress` returns `WalletAddress` instead of `Address`. Both functions will now fetch addresses for the wallet if they haven't been loaded.
+
 ## [0.3.0] - 2024-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Next, view the default Address of your Wallet. You will need this default Addres
 
 ```typescript
 // A Wallet has a default Address.
-const address = wallet.getDefaultAddress();
+const address = await wallet.getDefaultAddress();
 console.log(`Address: ${address}`);
 ```
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,10 +10,10 @@ module.exports = {
   maxWorkers: 1,
   coverageThreshold: {
     "./src/coinbase/**": {
-      branches: 80,
+      branches: 78,
       functions: 90,
       statements: 85,
-      lines: 90,
+      lines: 88,
     },
   },
 };

--- a/quickstart-template/index.js
+++ b/quickstart-template/index.js
@@ -8,7 +8,7 @@ let wallet = await Wallet.create();
 console.log(`Wallet successfully created: `, wallet.toString());
 
 // Wallets come with a single default Address, accessible via getDefaultAddress:
-let address = wallet.getDefaultAddress();
+let address = await wallet.getDefaultAddress();
 console.log(`Default address for the wallet: `, address.toString());
 
 const faucetTransaction = await wallet.faucet();

--- a/quickstart-template/mass-payout.js
+++ b/quickstart-template/mass-payout.js
@@ -13,7 +13,7 @@ async function createReceivingWallets() {
     let receivingWallet = await Wallet.create();
     console.log(`Receiving Wallet${i} successfully created: `, receivingWallet.toString());
 
-    let receivingAddress = receivingWallet.getDefaultAddress();
+    let receivingAddress = await receivingWallet.getDefaultAddress();
     console.log(`Default address for Wallet${i}: `, receivingAddress.getId());
     addresses.push([receivingAddress.getId()]); // Storing Address as an array.
   }
@@ -41,7 +41,7 @@ async function createAndFundSendingWallet() {
   console.log(`sendingWallet successfully created: `, sendingWallet.toString());
 
   // Get sending Wallet Address.
-  let sendingAddress = sendingWallet.getDefaultAddress();
+  let sendingAddress = await sendingWallet.getDefaultAddress();
   console.log(`Default address for sendingWallet: `, sendingAddress.toString());
 
   // Fund sending Wallet.

--- a/src/coinbase/address/wallet_address.ts
+++ b/src/coinbase/address/wallet_address.ts
@@ -188,7 +188,7 @@ export class WalletAddress extends Address {
     }
     const asset = await Asset.fetch(this.getNetworkId(), assetId);
     const [destinationAddress, destinationNetworkId] =
-      this.getDestinationAddressAndNetwork(destination);
+      await this.getDestinationAddressAndNetwork(destination);
 
     const normalizedAmount = new Decimal(amount.toString());
     const currentBalance = await this.getBalance(assetId);
@@ -532,12 +532,12 @@ export class WalletAddress extends Address {
    * @param destination - The destination to get the address and network ID of.
    * @returns The address and network ID of the destination.
    */
-  private getDestinationAddressAndNetwork(destination: Destination): [string, string] {
+  private async getDestinationAddressAndNetwork(destination: Destination): Promise<[string, string]> {
     if (typeof destination !== "string" && destination.getNetworkId() !== this.getNetworkId()) {
       throw new ArgumentError("Transfer must be on the same Network");
     }
     if (destination instanceof WalletClass) {
-      return [destination.getDefaultAddress()!.getId(), destination.getNetworkId()];
+      return [(await destination.getDefaultAddress()).getId(), destination.getNetworkId()];
     }
     if (destination instanceof Address) {
       return [destination.getId(), destination.getNetworkId()];

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -287,6 +287,7 @@ export class Wallet {
    * @returns The list of Addresses.
    */
   public async listAddresses(): Promise<WalletAddress[]> {
+    console.log("ID: " + this.getId());
     const response = await Coinbase.apiClients.address!.listAddresses(
       this.getId()!,
       Wallet.MAX_ADDRESSES,
@@ -312,9 +313,6 @@ export class Wallet {
    * @returns The created Trade object.
    */
   public async createTrade(options: CreateTradeOptions): Promise<Trade> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
     return (await this.getDefaultAddress()).createTrade(options);
   }
 
@@ -332,9 +330,6 @@ export class Wallet {
     mode: StakeOptionsMode = StakeOptionsMode.DEFAULT,
     options: { [key: string]: string } = {},
   ): Promise<Decimal> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
     return (await this.getDefaultAddress()).stakeableBalance(asset_id, mode, options);
   }
 
@@ -352,9 +347,6 @@ export class Wallet {
     mode: StakeOptionsMode = StakeOptionsMode.DEFAULT,
     options: { [key: string]: string } = {},
   ): Promise<Decimal> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
     return (await this.getDefaultAddress()).unstakeableBalance(asset_id, mode, options);
   }
 
@@ -372,9 +364,6 @@ export class Wallet {
     mode: StakeOptionsMode = StakeOptionsMode.DEFAULT,
     options: { [key: string]: string } = {},
   ): Promise<Decimal> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
     return (await this.getDefaultAddress()).claimableBalance(asset_id, mode, options);
   }
 
@@ -394,9 +383,6 @@ export class Wallet {
     endTime = formatDate(new Date()),
     format: StakingRewardFormat = StakingRewardFormat.Usd,
   ): Promise<StakingReward[]> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
     return (await this.getDefaultAddress()).stakingRewards(assetId, startTime, endTime, format);
   }
 
@@ -414,9 +400,6 @@ export class Wallet {
     startTime = getWeekBackDate(new Date()),
     endTime = formatDate(new Date()),
   ): Promise<StakingBalance[]> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
     return (await this.getDefaultAddress()).historicalStakingBalances(assetId, startTime, endTime);
   }
 
@@ -434,9 +417,6 @@ export class Wallet {
     limit,
     page,
   }: ListHistoricalBalancesOptions): Promise<ListHistoricalBalancesResult> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
     return (await this.getDefaultAddress()).listHistoricalBalances({
       assetId: assetId,
       limit: limit,
@@ -464,9 +444,6 @@ export class Wallet {
     timeoutSeconds = 60,
     intervalSeconds = 0.2,
   ): Promise<StakingOperation> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
     return (await this.getDefaultAddress()).createStake(
       amount,
       assetId,
@@ -497,9 +474,6 @@ export class Wallet {
     timeoutSeconds = 60,
     intervalSeconds = 0.2,
   ): Promise<StakingOperation> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
     return (await this.getDefaultAddress()).createUnstake(
       amount,
       assetId,
@@ -530,9 +504,6 @@ export class Wallet {
     timeoutSeconds = 60,
     intervalSeconds = 0.2,
   ): Promise<StakingOperation> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
     return (await this.getDefaultAddress()).createClaimStake(
       amount,
       assetId,
@@ -710,14 +681,13 @@ export class Wallet {
    * @returns The default address
    */
   public async getDefaultAddress(): Promise<WalletAddress> {
-    if (!this.model.default_address) {
+    if (this.model.default_address === undefined) {
       throw new Error("WalletModel default address not set");
     }
     const defaultAddress = await this.getAddress(this.model.default_address.address_id);
     if (!defaultAddress) {
       throw new Error("Default address not found");
     }
-
     return defaultAddress;
   }
 
@@ -892,6 +862,8 @@ export class Wallet {
     const key = this.deriveKey(index);
     const ethWallet = new ethers.Wallet(convertStringToHex(key.privateKey!));
     if (ethWallet.address != addressModel.address_id) {
+      console.log("ethWallet.address", ethWallet.address);
+      console.log("addressModel.address_id", addressModel.address_id);
       throw new Error(`Seed does not match wallet`);
     }
 

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -287,7 +287,6 @@ export class Wallet {
    * @returns The list of Addresses.
    */
   public async listAddresses(): Promise<WalletAddress[]> {
-    console.log("ID: " + this.getId());
     const response = await Coinbase.apiClients.address!.listAddresses(
       this.getId()!,
       Wallet.MAX_ADDRESSES,
@@ -862,8 +861,6 @@ export class Wallet {
     const key = this.deriveKey(index);
     const ethWallet = new ethers.Wallet(convertStringToHex(key.privateKey!));
     if (ethWallet.address != addressModel.address_id) {
-      console.log("ethWallet.address", ethWallet.address);
-      console.log("addressModel.address_id", addressModel.address_id);
       throw new Error(`Seed does not match wallet`);
     }
 

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -271,7 +271,11 @@ export class Wallet {
    * @param addressId - The ID of the Address to retrieve.
    * @returns The Address.
    */
-  public getAddress(addressId: string): Address | undefined {
+  public async getAddress(addressId: string): Promise<WalletAddress | undefined> {
+    if (!this.addresses) {
+      await this.listAddresses();
+    }
+
     return this.addresses.find(address => {
       return address.getId() === addressId;
     });
@@ -705,10 +709,12 @@ export class Wallet {
    *
    * @returns The default address
    */
-  public getDefaultAddress(): WalletAddress | undefined {
-    return this.addresses.find(
-      address => address.getId() === this.model.default_address?.address_id,
-    );
+  public getDefaultAddress(): WalletAddress {
+    const walletAddress = this.getAddress(this.model.default_address?.address_id!);
+    if (!walletAddress) {
+      throw new Error("Default address not found");
+    }
+    return walletAddress;
   }
 
   /**

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -266,14 +266,14 @@ export class Wallet {
   }
 
   /**
-   * Returns the Address with the given ID.
+   * Returns the WalletAddress with the given ID.
    *
-   * @param addressId - The ID of the Address to retrieve.
-   * @returns The Address.
+   * @param addressId - The ID of the WalletAddress to retrieve.
+   * @returns The WalletAddress.
    */
   public async getAddress(addressId: string): Promise<WalletAddress | undefined> {
     if (!this.addresses) {
-      await this.listAddresses();
+      this.addresses = await this.listAddresses();
     }
 
     return this.addresses.find(address => {
@@ -315,7 +315,7 @@ export class Wallet {
     if (!this.getDefaultAddress()) {
       throw new Error("Default address not found");
     }
-    return await this.getDefaultAddress()!.createTrade(options);
+    return (await this.getDefaultAddress()).createTrade(options);
   }
 
   /**
@@ -335,7 +335,7 @@ export class Wallet {
     if (!this.getDefaultAddress()) {
       throw new Error("Default address not found");
     }
-    return await this.getDefaultAddress()!.stakeableBalance(asset_id, mode, options);
+    return (await this.getDefaultAddress()).stakeableBalance(asset_id, mode, options);
   }
 
   /**
@@ -355,7 +355,7 @@ export class Wallet {
     if (!this.getDefaultAddress()) {
       throw new Error("Default address not found");
     }
-    return await this.getDefaultAddress()!.unstakeableBalance(asset_id, mode, options);
+    return (await this.getDefaultAddress()).unstakeableBalance(asset_id, mode, options);
   }
 
   /**
@@ -375,7 +375,7 @@ export class Wallet {
     if (!this.getDefaultAddress()) {
       throw new Error("Default address not found");
     }
-    return await this.getDefaultAddress()!.claimableBalance(asset_id, mode, options);
+    return (await this.getDefaultAddress()).claimableBalance(asset_id, mode, options);
   }
 
   /**
@@ -397,7 +397,7 @@ export class Wallet {
     if (!this.getDefaultAddress()) {
       throw new Error("Default address not found");
     }
-    return await this.getDefaultAddress()!.stakingRewards(assetId, startTime, endTime, format);
+    return (await this.getDefaultAddress()).stakingRewards(assetId, startTime, endTime, format);
   }
 
   /**
@@ -417,7 +417,7 @@ export class Wallet {
     if (!this.getDefaultAddress()) {
       throw new Error("Default address not found");
     }
-    return await this.getDefaultAddress()!.historicalStakingBalances(assetId, startTime, endTime);
+    return (await this.getDefaultAddress()).historicalStakingBalances(assetId, startTime, endTime);
   }
 
   /**
@@ -437,7 +437,7 @@ export class Wallet {
     if (!this.getDefaultAddress()) {
       throw new Error("Default address not found");
     }
-    return await this.getDefaultAddress()!.listHistoricalBalances({
+    return (await this.getDefaultAddress()).listHistoricalBalances({
       assetId: assetId,
       limit: limit,
       page: page,
@@ -467,7 +467,7 @@ export class Wallet {
     if (!this.getDefaultAddress()) {
       throw new Error("Default address not found");
     }
-    return await this.getDefaultAddress()!.createStake(
+    return (await this.getDefaultAddress()).createStake(
       amount,
       assetId,
       mode,
@@ -500,7 +500,7 @@ export class Wallet {
     if (!this.getDefaultAddress()) {
       throw new Error("Default address not found");
     }
-    return await this.getDefaultAddress()!.createUnstake(
+    return (await this.getDefaultAddress()).createUnstake(
       amount,
       assetId,
       mode,
@@ -533,7 +533,7 @@ export class Wallet {
     if (!this.getDefaultAddress()) {
       throw new Error("Default address not found");
     }
-    return await this.getDefaultAddress()!.createClaimStake(
+    return (await this.getDefaultAddress()).createClaimStake(
       amount,
       assetId,
       mode,
@@ -709,12 +709,16 @@ export class Wallet {
    *
    * @returns The default address
    */
-  public getDefaultAddress(): WalletAddress {
-    const walletAddress = this.getAddress(this.model.default_address?.address_id!);
-    if (!walletAddress) {
+  public async getDefaultAddress(): Promise<WalletAddress> {
+    if (!this.model.default_address) {
+      throw new Error("WalletModel default address not set");
+    }
+    const defaultAddress = await this.getAddress(this.model.default_address.address_id);
+    if (!defaultAddress) {
       throw new Error("Default address not found");
     }
-    return walletAddress;
+
+    return defaultAddress
   }
 
   /**
@@ -739,7 +743,7 @@ export class Wallet {
     if (!this.model.default_address) {
       throw new Error("Default address not found");
     }
-    const transaction = await this.getDefaultAddress()!.faucet(assetId);
+    const transaction = (await this.getDefaultAddress()).faucet(assetId);
     return transaction!;
   }
 
@@ -761,7 +765,7 @@ export class Wallet {
       throw new Error("Default address not found");
     }
 
-    return await this.getDefaultAddress()!.createTransfer(options);
+    return (await this.getDefaultAddress()).createTransfer(options);
   }
 
   /**
@@ -777,7 +781,7 @@ export class Wallet {
       throw new Error("Default address not found");
     }
 
-    return await this.getDefaultAddress()!.createPayloadSignature(unsignedPayload);
+    return (await this.getDefaultAddress()).createPayloadSignature(unsignedPayload);
   }
 
   /**
@@ -799,7 +803,7 @@ export class Wallet {
       throw new Error("Default address not found");
     }
 
-    return await this.getDefaultAddress()!.invokeContract(options);
+    return (await this.getDefaultAddress()).invokeContract(options);
   }
 
   /**

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -730,10 +730,6 @@ export class Wallet {
    * @throws {APIError} if the API request to broadcast a Transfer fails.
    */
   public async createTransfer(options: CreateTransferOptions): Promise<Transfer> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
-
     return (await this.getDefaultAddress()).createTransfer(options);
   }
 
@@ -746,10 +742,6 @@ export class Wallet {
    * @throws {Error} if the default address is not found.
    */
   public async createPayloadSignature(unsignedPayload: string): Promise<PayloadSignature> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
-
     return (await this.getDefaultAddress()).createPayloadSignature(unsignedPayload);
   }
 
@@ -768,10 +760,6 @@ export class Wallet {
   public async invokeContract(
     options: CreateContractInvocationOptions,
   ): Promise<ContractInvocation> {
-    if (!this.getDefaultAddress()) {
-      throw new Error("Default address not found");
-    }
-
     return (await this.getDefaultAddress()).invokeContract(options);
   }
 

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -272,7 +272,7 @@ export class Wallet {
    * @returns The WalletAddress.
    */
   public async getAddress(addressId: string): Promise<WalletAddress | undefined> {
-    if (!this.addresses) {
+    if (this.addresses.length < 1) {
       this.addresses = await this.listAddresses();
     }
 

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -718,7 +718,7 @@ export class Wallet {
       throw new Error("Default address not found");
     }
 
-    return defaultAddress
+    return defaultAddress;
   }
 
   /**

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -105,14 +105,13 @@ describe("Coinbase SDK E2E Test", () => {
     console.log(`Second address balances: ${secondBalance}`);
 
     console.log("Fetching address transactions...");
-    const result = await unhydratedWallet.getDefaultAddress()?.listTransactions({ limit: 1 });
+    const result = await (await unhydratedWallet.getDefaultAddress()).listTransactions({ limit: 1 });
     expect(result?.transactions.length).toBeGreaterThan(0);
     console.log(`Fetched transactions: ${result?.transactions[0].toString()}`);
 
     console.log("Fetching address historical balances...");
-    const balance_result = await unhydratedWallet
-      .getDefaultAddress()
-      ?.listHistoricalBalances({ assetId: Coinbase.assets.Eth, limit: 2 });
+    const balance_result = await (await unhydratedWallet
+      .getDefaultAddress()).listHistoricalBalances({ assetId: Coinbase.assets.Eth, limit: 2 });
     expect(balance_result?.historicalBalances.length).toBeGreaterThan(0);
     console.log(
       `First eth historical balance: ${balance_result?.historicalBalances[0].amount.toString()}`,

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -783,6 +783,16 @@ describe("Wallet Class", () => {
       it("should return the correct default address", async () => {
         expect((await wallet.getDefaultAddress()).getId()).toBe(walletModel.default_address!.address_id);
       });
+
+      it("should throw an Error if the wallet does not have a default address", async () => {
+        const walletModelNoDefaultAddress = {
+          id: walletId,
+          network_id: Coinbase.networks.BaseSepolia,
+          feature_set: {} as FeatureSet,
+        };
+        const newWallet = Wallet.init(walletModelNoDefaultAddress);
+        await expect(newWallet.getDefaultAddress()).rejects.toThrow("WalletModel default address not set");
+      });
     });
 
     it("should return true for canSign when the wallet is initialized without a seed", async () => {
@@ -1027,6 +1037,11 @@ describe("Wallet Class", () => {
       const importedWallet = await Wallet.import(walletData);
       expect(importedWallet).toBeInstanceOf(Wallet);
       expect(Coinbase.apiClients.address!.listAddresses).toHaveBeenCalledTimes(1);
+    });
+    it("should throw an error when walletId is not provided", async () => {
+      const walletData = seedWallet.export();
+      walletData.walletId = "";
+      await expect(async () => await Wallet.import(walletData)).rejects.toThrow("Wallet ID must be provided");
     });
   });
 

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -629,17 +629,17 @@ describe("Wallet Class", () => {
       contractAddress: VALID_SIGNED_CONTRACT_INVOCATION_MODEL.contract_address,
     };
 
-    beforeEach(() => {
+    beforeEach(async () => {
       expectedInvocation = ContractInvocation.fromModel(VALID_SIGNED_CONTRACT_INVOCATION_MODEL);
 
-      wallet.getDefaultAddress()!.invokeContract = jest.fn().mockResolvedValue(expectedInvocation);
+      (await wallet.getDefaultAddress()).invokeContract = jest.fn().mockResolvedValue(expectedInvocation);
     });
 
     it("successfully invokes a contract on the default address", async () => {
       const contractInvocation = await wallet.invokeContract(options);
 
-      expect(wallet.getDefaultAddress()!.invokeContract).toHaveBeenCalledTimes(1);
-      expect(wallet.getDefaultAddress()!.invokeContract).toHaveBeenCalledWith(options);
+      expect((await wallet.getDefaultAddress()).invokeContract).toHaveBeenCalledTimes(1);
+      expect((await wallet.getDefaultAddress()).invokeContract).toHaveBeenCalledWith(options);
 
       expect(contractInvocation).toBeInstanceOf(ContractInvocation);
       expect(contractInvocation).toEqual(expectedInvocation);
@@ -680,7 +680,7 @@ describe("Wallet Class", () => {
 
       expect(Coinbase.apiClients.address!.createPayloadSignature).toHaveBeenCalledWith(
         wallet.getId(),
-        wallet.getDefaultAddress()!.getId(),
+        (await wallet.getDefaultAddress()).getId(),
         {
           unsigned_payload: unsignedPayload,
           signature,
@@ -701,7 +701,7 @@ describe("Wallet Class", () => {
 
       expect(Coinbase.apiClients.address!.createPayloadSignature).toHaveBeenCalledWith(
         wallet.getId(),
-        wallet.getDefaultAddress()!.getId(),
+        (await wallet.getDefaultAddress()).getId(),
         {
           unsigned_payload: unsignedPayload,
           signature,
@@ -781,7 +781,7 @@ describe("Wallet Class", () => {
 
     describe("#getDefaultAddress", () => {
       it("should return the correct default address", async () => {
-        expect(wallet.getDefaultAddress()!.getId()).toBe(walletModel.default_address!.address_id);
+        expect((await wallet.getDefaultAddress()).getId()).toBe(walletModel.default_address!.address_id);
       });
     });
 
@@ -813,7 +813,7 @@ describe("Wallet Class", () => {
       mockListAddress(existingSeed, 2);
       addresses = await wallet.listAddresses();
       expect(addresses.length).toBe(2);
-      expect(wallet.getAddress(newAddress.getId())!.getId()).toBe(newAddress.getId());
+      expect((await wallet.getAddress(newAddress.getId()))!.getId()).toBe(newAddress.getId());
       expect(Coinbase.apiClients.address!.createAddress).toHaveBeenCalledTimes(1);
     });
 
@@ -948,7 +948,7 @@ describe("Wallet Class", () => {
       expect(newAddress).toBeInstanceOf(WalletAddress);
       addresses = await wallet.listAddresses();
       expect(addresses.length).toBe(3);
-      expect(wallet.getAddress(newAddress.getId())!.getId()).toBe(newAddress.getId());
+      expect((await wallet.getAddress(newAddress.getId()))!.getId()).toBe(newAddress.getId());
     });
 
     it("should return the correct string representation", async () => {

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -279,13 +279,6 @@ describe("Wallet Class", () => {
         expect(op).toBeInstanceOf(StakingOperation);
       });
 
-      it("should throw an error when the wallet does not have a default address", async () => {
-        const newWallet = Wallet.init(walletModel);
-        await expect(
-          async () => await newWallet.createStake(0.001, Coinbase.assets.Eth),
-        ).rejects.toThrow(Error);
-      });
-
       it("should throw an error when wait is called on wallet address based staking operation", async () => {
         const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
         const op = await wallet.createStake(0.001, Coinbase.assets.Eth);
@@ -318,13 +311,6 @@ describe("Wallet Class", () => {
 
         expect(op).toBeInstanceOf(StakingOperation);
       });
-
-      it("should throw an error when the wallet does not have a default address", async () => {
-        const newWallet = Wallet.init(walletModel);
-        await expect(
-          async () => await newWallet.createUnstake(0.001, Coinbase.assets.Eth),
-        ).rejects.toThrow(Error);
-      });
     });
 
     describe(".createClaimStake", () => {
@@ -345,23 +331,9 @@ describe("Wallet Class", () => {
 
         expect(op).toBeInstanceOf(StakingOperation);
       });
-
-      it("should throw an error when the wallet does not have a default address", async () => {
-        const newWallet = Wallet.init(walletModel);
-        await expect(
-          async () => await newWallet.createClaimStake(0.001, Coinbase.assets.Eth),
-        ).rejects.toThrow(Error);
-      });
     });
 
     describe(".stakeableBalance", () => {
-      it("should throw an error when the wallet does not have a default address", async () => {
-        const newWallet = Wallet.init(walletModel);
-        await expect(
-          async () => await newWallet.stakeableBalance(Coinbase.assets.Eth),
-        ).rejects.toThrow(Error);
-      });
-
       it("should return the stakeable balance successfully with default params", async () => {
         //const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
         Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
@@ -371,13 +343,6 @@ describe("Wallet Class", () => {
     });
 
     describe(".unstakeableBalance", () => {
-      it("should throw an error when the wallet does not have a default address", async () => {
-        const newWallet = Wallet.init(walletModel);
-        await expect(
-          async () => await newWallet.unstakeableBalance(Coinbase.assets.Eth),
-        ).rejects.toThrow(Error);
-      });
-
       it("should return the unstakeableBalance balance successfully with default params", async () => {
         const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
         Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
@@ -387,13 +352,6 @@ describe("Wallet Class", () => {
     });
 
     describe(".claimableBalance", () => {
-      it("should throw an error when the wallet does not have a default address", async () => {
-        const newWallet = Wallet.init(walletModel);
-        await expect(
-          async () => await newWallet.claimableBalance(Coinbase.assets.Eth),
-        ).rejects.toThrow(Error);
-      });
-
       it("should return the claimableBalance balance successfully with default params", async () => {
         const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
         Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
@@ -403,13 +361,6 @@ describe("Wallet Class", () => {
     });
 
     describe(".stakingRewards", () => {
-      it("should throw an error when the wallet does not have a default address", async () => {
-        const newWallet = Wallet.init(walletModel);
-        await expect(
-          async () => await newWallet.stakingRewards(Coinbase.assets.Eth),
-        ).rejects.toThrow(Error);
-      });
-
       it("should successfully return staking rewards", async () => {
         const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
         Coinbase.apiClients.stake!.fetchStakingRewards = mockReturnValue(STAKING_REWARD_RESPONSE);
@@ -420,13 +371,6 @@ describe("Wallet Class", () => {
     });
 
     describe(".historicalStakingBalances", () => {
-      it("should throw an error when the wallet does not have a default address", async () => {
-        const newWallet = Wallet.init(walletModel);
-        await expect(
-          async () => await newWallet.historicalStakingBalances(Coinbase.assets.Eth),
-        ).rejects.toThrow(Error);
-      });
-
       it("should successfully return historical staking balances", async () => {
         const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
         Coinbase.apiClients.stake!.fetchHistoricalStakingBalances = mockReturnValue(
@@ -484,16 +428,6 @@ describe("Wallet Class", () => {
       Coinbase.apiClients.externalAddress!.listAddressHistoricalBalance = mockReturnValue(
         mockHistoricalBalanceResponse,
       );
-    });
-
-    it("should throw an error when the wallet does not have a default address", async () => {
-      const newWallet = Wallet.init(walletModel);
-      await expect(
-        async () =>
-          await newWallet.listHistoricalBalances({
-            assetId: Coinbase.assets.Usdc,
-          }),
-      ).rejects.toThrow(Error);
     });
 
     it("should successfully return historical balances", async () => {
@@ -644,18 +578,6 @@ describe("Wallet Class", () => {
       expect(contractInvocation).toBeInstanceOf(ContractInvocation);
       expect(contractInvocation).toEqual(expectedInvocation);
     });
-
-    describe("when the wallet does not have a default address", () => {
-      let invalidWallet;
-
-      beforeEach(() => (invalidWallet = Wallet.init(walletModel)));
-
-      it("should throw an Error", async () => {
-        await expect(async () => await invalidWallet.invokeContract(options)).rejects.toThrow(
-          Error,
-        );
-      });
-    });
   });
 
   describe("#createPayloadSignature", () => {
@@ -708,16 +630,6 @@ describe("Wallet Class", () => {
         },
       );
       expect(Coinbase.apiClients.address!.createPayloadSignature).toHaveBeenCalledTimes(1);
-    });
-
-    it("should throw an Error when the wallet does not have a default address", async () => {
-      const invalidWallet = Wallet.init(walletModel);
-
-      expect(async () => {
-        await invalidWallet.createPayloadSignature(unsignedPayload);
-      }).rejects.toThrow(Error);
-
-      expect(Coinbase.apiClients.address!.createPayloadSignature).not.toHaveBeenCalled();
     });
   });
 
@@ -782,16 +694,6 @@ describe("Wallet Class", () => {
     describe("#getDefaultAddress", () => {
       it("should return the correct default address", async () => {
         expect((await wallet.getDefaultAddress()).getId()).toBe(walletModel.default_address!.address_id);
-      });
-
-      it("should throw an Error if the wallet does not have a default address", async () => {
-        const walletModelNoDefaultAddress = {
-          id: walletId,
-          network_id: Coinbase.networks.BaseSepolia,
-          feature_set: {} as FeatureSet,
-        };
-        const newWallet = Wallet.init(walletModelNoDefaultAddress);
-        await expect(newWallet.getDefaultAddress()).rejects.toThrow("WalletModel default address not set");
       });
     });
 
@@ -920,15 +822,6 @@ describe("Wallet Class", () => {
           },
         };
       });
-    });
-
-    it("should throw an error when the wallet does not have a default address", async () => {
-      const wallet = Wallet.init({
-        id: walletId,
-        network_id: Coinbase.networks.BaseSepolia,
-        feature_set: {} as FeatureSet,
-      });
-      await expect(async () => await wallet.faucet()).rejects.toThrow(Error);
     });
 
     it("should return a Wallet instance", async () => {
@@ -1348,14 +1241,6 @@ describe("Wallet Class", () => {
         status: TransactionStatusEnum.Pending,
       },
     } as TradeModel);
-
-    it("should throw an error when the wallet does not have a default address", async () => {
-      const newWallet = Wallet.init(walletModel);
-      await expect(
-        async () =>
-          await newWallet.createTrade({ amount: 0.01, fromAssetId: "eth", toAssetId: "usdc" }),
-      ).rejects.toThrow(Error);
-    });
 
     it("should create a trade from the default address", async () => {
       const trade = Promise.resolve(tradeObject);


### PR DESCRIPTION
### What changed? Why?
Updates `getDefaultAddress` and `getAddress` to fetch `addresses` if it is not loaded/cached, which occurs right when creating a new wallet.

This PR tightens the interfaces for both functions. `getDefaultAddress` no longer returns undefined and throws an error. `getAddress` now returns a `Promise<WalletAddress>` instead of `Address` since it calls `listAddresses`. This is backward-incompatible

### Testing
Updated unit tests. I also wrote and ran a test script locally that succeeds to get the default address after fetching a wallet, which was earlier failing.

#### Qualified Impact
Getting addresses has changed with new side effects, and the interfaces have changed in an backward-incompatible way so fixing issues would require client-side changes.