### PR TITLE
Added Coinbase.configure function, marked constructor as deprecated, and updated docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ dist
 .tern-port
 
 # Stores VSCode versions used for testing VSCode extensions
+.vscode
 .vscode-test
 
 # yarn v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `Coinbase.configure` method to allow for configuration of the SDK and marked constructor as deprecated.
+
 ## [0.4.0] - 2024-09-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -79,18 +79,18 @@ const apiKeyName = "Copy your API Key name here.";
 
 const privateKey = "Copy your API Key's private key here.";
 
-const coinbase = new Coinbase({ apiKeyName: apiKeyName, privateKey: privateKey });
+Coinbase.configure({ apiKeyName: apiKeyName, privateKey: privateKey });
 ```
 
 If you are using a CDP Server-Signer to manage your private keys, enable it with the constuctor option:
 ```typescript
-const coinbase = new Coinbase({ apiKeyName: apiKeyName, privateKey: apiKeyPrivateKey, useServerSigner: true })
+Coinbase.configure({ apiKeyName: apiKeyName, privateKey: apiKeyPrivateKey, useServerSigner: true })
 ```
 
 Another way to initialize the SDK is by sourcing the API key from the json file that contains your API key, downloaded from CDP portal.
 
 ```typescript
-const coinbase = Coinbase.configureFromJson({ filePath: "path/to/your/api-key.json" });
+Coinbase.configureFromJson({ filePath: "path/to/your/api-key.json" });
 ```
 
 This will allow you to authenticate with the Platform APIs.
@@ -99,7 +99,7 @@ CommonJs:
 
 ```javascript
 const { Coinbase, Wallet } = require("@coinbase/coinbase-sdk");
-const coinbase = Coinbase.configureFromJson("path/to/your/api-key.json");
+Coinbase.configureFromJson("path/to/your/api-key.json");
 
 // List all Wallets for the CDP Project.
 Wallet.listWallets().then(wallets => {
@@ -111,7 +111,7 @@ Or using ES modules and async/await:
 
 ```typescript
 import { Coinbase, Wallet } from "@coinbase/coinbase-sdk";
-const coinbase = Coinbase.configureFromJson("path/to/your/api-key.json");
+Coinbase.configureFromJson("path/to/your/api-key.json");
 
 // List all Wallets for the CDP Project.
 const wallets = await Wallet.listWallets();

--- a/quickstart-template/index.js
+++ b/quickstart-template/index.js
@@ -1,7 +1,7 @@
 import { Coinbase, Wallet } from "@coinbase/coinbase-sdk";
 
 // Change this to the path of your API key file downloaded from CDP portal.
-let coinbase = Coinbase.configureFromJson({ filePath: "~/Downloads/cdp_api_key.json" });
+Coinbase.configureFromJson({ filePath: "~/Downloads/cdp_api_key.json" });
 
 // Create a Wallet for the User.
 let wallet = await Wallet.create();

--- a/quickstart-template/mass-payout.js
+++ b/quickstart-template/mass-payout.js
@@ -92,7 +92,7 @@ async function sendMassPayout(sendingWallet) {
   try {
     // Manage CDP Api Key for Coinbase SDK.
     // Configure location to CDP API Key.
-    let coinbase = Coinbase.configureFromJson({
+    Coinbase.configureFromJson({
       filePath: `${os.homedir()}/Downloads/cdp_api_key.json`,
     });
 

--- a/quickstart-template/trade-assets.js
+++ b/quickstart-template/trade-assets.js
@@ -1,6 +1,6 @@
 import { Coinbase, Wallet } from "@coinbase/coinbase-sdk";
 
-let coinbase = Coinbase.configureFromJson({ filePath: "~/Downloads/cdp_api_key.json" });
+Coinbase.configureFromJson({ filePath: "~/Downloads/cdp_api_key.json" });
 
 // Create a Wallet on base-mainnet to trade assets with.
 let wallet = await Wallet.create({ networkId: Coinbase.networks.BaseMainnet });

--- a/src/coinbase/coinbase.ts
+++ b/src/coinbase/coinbase.ts
@@ -74,6 +74,8 @@ export class Coinbase {
   /**
    * Initializes the Coinbase SDK.
    *
+   * @deprecated as of v0.5.0, use `configure` or `configureFromJson` instead.
+   *
    * @class
    * @param options - The constructor options.
    * @param options.apiKeyName - The API key name.
@@ -144,6 +146,33 @@ export class Coinbase {
     Coinbase.apiClients.smartContract = ContractEventsApiFactory(config, basePath, axiosInstance);
     Coinbase.apiKeyPrivateKey = privateKey;
     Coinbase.useServerSigner = useServerSigner;
+  }
+
+  /**
+   * Configures the Coinbase SDK with the provided options.
+   *
+   * @param options - The configuration options.
+   * @param options.apiKeyName - The name of the API key.
+   * @param options.privateKey - The private key associated with the API key.
+   * @param options.useServerSigner - Whether to use a Server-Signer or not. Defaults to false.
+   * @param options.debugging - If true, logs API requests and responses to the console. Defaults to false.
+   * @param options.basePath - The base path for the API. Defaults to BASE_PATH.
+   * @returns A new instance of the Coinbase SDK.
+   */
+  static configure({
+    apiKeyName,
+    privateKey,
+    useServerSigner = false,
+    debugging = false,
+    basePath = BASE_PATH,
+  }: CoinbaseOptions) {
+    return new Coinbase({
+      apiKeyName,
+      privateKey,
+      useServerSigner,
+      debugging,
+      basePath,
+    });
   }
 
   /**

--- a/src/tests/coinbase_test.ts
+++ b/src/tests/coinbase_test.ts
@@ -32,10 +32,10 @@ describe("Coinbase tests", () => {
   });
 
   it("should throw an error if the API key name or private key is empty", () => {
-    expect(() => new Coinbase({ apiKeyName: "", privateKey: "test" })).toThrow(
+    expect(() => Coinbase.configure({ apiKeyName: "", privateKey: "test" })).toThrow(
       "Invalid configuration: apiKeyName is empty",
     );
-    expect(() => new Coinbase({ apiKeyName: "test", privateKey: "" })).toThrow(
+    expect(() => Coinbase.configure({ apiKeyName: "test", privateKey: "" })).toThrow(
       "Invalid configuration: privateKey is empty",
     );
   });

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -4,13 +4,12 @@ import { Coinbase, Wallet } from "../index";
 import { TransferStatus } from "../coinbase/types";
 
 describe("Coinbase SDK E2E Test", () => {
-  let coinbase: Coinbase;
   beforeAll(() => {
     dotenv.config();
   });
 
   beforeEach(() => {
-    coinbase = new Coinbase({
+    new Coinbase({
       apiKeyName: process.env.NAME as string,
       privateKey: process.env.PRIVATE_KEY as string,
     });

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -9,7 +9,7 @@ describe("Coinbase SDK E2E Test", () => {
   });
 
   beforeEach(() => {
-    new Coinbase({
+    Coinbase.configure({
       apiKeyName: process.env.NAME as string,
       privateKey: process.env.PRIVATE_KEY as string,
     });


### PR DESCRIPTION
### What changed? Why?
The initialized `Coinbase` instance from our constructor is unused, since we're essentially doing a singleton pattern by initializing the static api clients and using them from other classes e.g. `Wallet`. We plan to make `Coinbase` a true singleton later on, and we plan to make the constructor private when we plan for some backward-incompatible changes.

For now, this PR:
- Marks the constructor as `@deprecated`
- Creates a new `configure` function that can be used instead of the constructor
- Updates tests and docs to use `configure` instead of the constructor and to not assign to a local variable which is unused anyway.