### PR TITLE
feat: Expose staking reward format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `Coinbase.configure` method to allow for configuration of the SDK and marked constructor as deprecated.
 - Return correlation ID from APIError response
 - Add optional fields to `CreateContractInvocationOptions` to set amount for payable contract method invocations
+- Add a `StakingRewardFormat` enum to allow for specifying the format in which staking rewards should be returned.
 
 ## [0.4.0] - 2024-09-06
 

--- a/src/coinbase/address.ts
+++ b/src/coinbase/address.ts
@@ -8,13 +8,13 @@ import { HistoricalBalance } from "./historical_balance";
 import {
   Amount,
   StakeOptionsMode,
+  StakingRewardFormat,
   ListHistoricalBalancesResult,
   ListHistoricalBalancesOptions,
   ListTransactionsOptions,
   ListTransactionsResult,
 } from "./types";
 import { formatDate, getWeekBackDate } from "./utils";
-import { StakingRewardFormat } from "../client";
 import { StakingReward } from "./staking_reward";
 import { StakingBalance } from "./staking_balance";
 import { Transaction } from "./transaction";
@@ -201,7 +201,7 @@ export class Address {
     assetId: string,
     startTime = getWeekBackDate(new Date()),
     endTime = formatDate(new Date()),
-    format: StakingRewardFormat = StakingRewardFormat.Usd,
+    format: StakingRewardFormat = StakingRewardFormat.USD,
   ): Promise<StakingReward[]> {
     return StakingReward.list(
       Coinbase.normalizeNetwork(this.getNetworkId()),

--- a/src/coinbase/staking_reward.ts
+++ b/src/coinbase/staking_reward.ts
@@ -1,8 +1,8 @@
-import { StakingRewardFormat, StakingReward as StakingRewardModel } from "../client";
+import { StakingReward as StakingRewardModel } from "../client";
 import Decimal from "decimal.js";
 import { Coinbase } from "./coinbase";
 import { Asset } from "./asset";
-import { Amount } from "./types";
+import { Amount, StakingRewardFormat } from "./types";
 
 /**
  * A representation of a staking reward earned on a network for a given asset.
@@ -10,7 +10,7 @@ import { Amount } from "./types";
 export class StakingReward {
   private model: StakingRewardModel;
   private asset: Asset;
-  private format: StakingRewardFormat;
+  private readonly format: StakingRewardFormat;
 
   /**
    * Creates the StakingReward object.
@@ -42,7 +42,7 @@ export class StakingReward {
     addressIds: Array<string>,
     startTime: string,
     endTime: string,
-    format: StakingRewardFormat = StakingRewardFormat.Usd,
+    format: StakingRewardFormat = StakingRewardFormat.USD,
   ): Promise<StakingReward[]> {
     const stakingRewards: StakingReward[] = [];
     const queue: string[] = [""];
@@ -85,7 +85,7 @@ export class StakingReward {
    * @returns The amount.
    */
   public amount(): Amount {
-    if (this.format == StakingRewardFormat.Usd) {
+    if (this.format == StakingRewardFormat.USD) {
       return new Decimal(this.model.amount).div(new Decimal("100"));
     }
     return this.asset.fromAtomicAmount(new Decimal(this.model.amount)).toNumber();

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -777,6 +777,15 @@ export enum ValidatorStatus {
 }
 
 /**
+ * Staking reward format type definition.
+ * Represents the format in which staking rewards can be queried.
+ */
+export enum StakingRewardFormat {
+  USD = "usd",
+  NATIVE = "native",
+}
+
+/**
  * Payload Signature status type definition.
  */
 export enum PayloadSignatureStatus {

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -4,7 +4,7 @@ import Decimal from "decimal.js";
 import { ethers } from "ethers";
 import * as fs from "fs";
 import * as secp256k1 from "secp256k1";
-import { Address as AddressModel, Wallet as WalletModel, StakingRewardFormat } from "../client";
+import { Address as AddressModel, Wallet as WalletModel } from "../client";
 import { Address } from "./address";
 import { WalletAddress } from "./address/wallet_address";
 import { Asset } from "./asset";
@@ -17,6 +17,7 @@ import { Trade } from "./trade";
 import { Transfer } from "./transfer";
 import {
   Amount,
+  StakingRewardFormat,
   CreateContractInvocationOptions,
   CreateTransferOptions,
   CreateTradeOptions,
@@ -380,7 +381,7 @@ export class Wallet {
     assetId: string,
     startTime = getWeekBackDate(new Date()),
     endTime = formatDate(new Date()),
-    format: StakingRewardFormat = StakingRewardFormat.Usd,
+    format: StakingRewardFormat = StakingRewardFormat.USD,
   ): Promise<StakingReward[]> {
     return (await this.getDefaultAddress()).stakingRewards(assetId, startTime, endTime, format);
   }

--- a/src/tests/staking_reward_test.ts
+++ b/src/tests/staking_reward_test.ts
@@ -1,8 +1,4 @@
-import {
-  FetchStakingRewards200Response,
-  StakingRewardFormat,
-  StakingRewardStateEnum,
-} from "../client";
+import { FetchStakingRewards200Response, StakingRewardStateEnum } from "../client";
 import { Coinbase } from "../coinbase/coinbase";
 import {
   assetsApiMock,
@@ -12,6 +8,7 @@ import {
   newAddressModel,
   stakeApiMock,
 } from "./utils";
+import { StakingRewardFormat } from "../coinbase/types";
 import { StakingReward } from "../coinbase/staking_reward";
 import { ExternalAddress } from "../coinbase/address/external_address";
 import { Asset } from "../coinbase/asset";
@@ -35,7 +32,7 @@ describe("StakingReward", () => {
         date: "2024-05-01",
         amount: "361",
         state: StakingRewardStateEnum.Pending,
-        format: StakingRewardFormat.Usd,
+        format: "usd",
         usd_value: {
           amount: "361",
           conversion_price: "3000",
@@ -47,7 +44,7 @@ describe("StakingReward", () => {
         date: "2024-05-02",
         amount: "203",
         state: StakingRewardStateEnum.Pending,
-        format: StakingRewardFormat.Usd,
+        format: "usd",
         usd_value: {
           amount: "203",
           conversion_price: "3000",
@@ -59,7 +56,7 @@ describe("StakingReward", () => {
         date: "2024-05-03",
         amount: "226",
         state: StakingRewardStateEnum.Pending,
-        format: StakingRewardFormat.Usd,
+        format: "usd",
         usd_value: {
           amount: "226",
           conversion_price: "3000",
@@ -100,7 +97,7 @@ describe("StakingReward", () => {
           address_ids: [address.getId()],
           start_time: startTime,
           end_time: endTime,
-          format: StakingRewardFormat.Usd,
+          format: StakingRewardFormat.USD,
         },
         100,
         undefined,
@@ -130,7 +127,7 @@ describe("StakingReward", () => {
           address_ids: [address.getId()],
           start_time: startTime,
           end_time: endTime,
-          format: StakingRewardFormat.Usd,
+          format: StakingRewardFormat.USD,
         },
         100,
         undefined,
@@ -146,7 +143,7 @@ describe("StakingReward", () => {
           date: "2024-05-03",
           amount: "226",
           state: StakingRewardStateEnum.Pending,
-          format: StakingRewardFormat.Usd,
+          format: StakingRewardFormat.USD,
           usd_value: {
             amount: "226",
             conversion_price: "3000",
@@ -154,7 +151,7 @@ describe("StakingReward", () => {
           },
         },
         asset,
-        StakingRewardFormat.Usd,
+        StakingRewardFormat.USD,
       );
 
       const amount = reward.amount();
@@ -170,7 +167,7 @@ describe("StakingReward", () => {
           date: "2024-05-03",
           amount: "726030823305604",
           state: StakingRewardStateEnum.Pending,
-          format: StakingRewardFormat.Native,
+          format: StakingRewardFormat.NATIVE,
           usd_value: {
             amount: "179",
             conversion_price: "2461.63",
@@ -178,7 +175,7 @@ describe("StakingReward", () => {
           },
         },
         asset,
-        StakingRewardFormat.Native,
+        StakingRewardFormat.NATIVE,
       );
 
       const amount = reward.amount();
@@ -194,7 +191,7 @@ describe("StakingReward", () => {
           date: "2024-05-03",
           amount: "226",
           state: StakingRewardStateEnum.Pending,
-          format: StakingRewardFormat.Usd,
+          format: StakingRewardFormat.USD,
           usd_value: {
             amount: "226",
             conversion_price: "3000",
@@ -202,7 +199,7 @@ describe("StakingReward", () => {
           },
         },
         asset,
-        StakingRewardFormat.Usd,
+        StakingRewardFormat.USD,
       );
 
       const date = reward.date();
@@ -220,7 +217,7 @@ describe("StakingReward", () => {
           date: "2024-05-03",
           amount: "226",
           state: StakingRewardStateEnum.Pending,
-          format: StakingRewardFormat.Usd,
+          format: StakingRewardFormat.USD,
           usd_value: {
             amount: "226",
             conversion_price: "3000",
@@ -228,7 +225,7 @@ describe("StakingReward", () => {
           },
         },
         asset,
-        StakingRewardFormat.Usd,
+        StakingRewardFormat.USD,
       );
 
       const rewardStr = reward.toString();
@@ -246,7 +243,7 @@ describe("StakingReward", () => {
           date: "2024-05-03",
           amount: "226",
           state: StakingRewardStateEnum.Pending,
-          format: StakingRewardFormat.Usd,
+          format: StakingRewardFormat.USD,
           usd_value: {
             amount: "226",
             conversion_price: "3000",
@@ -254,7 +251,7 @@ describe("StakingReward", () => {
           },
         },
         asset,
-        StakingRewardFormat.Usd,
+        StakingRewardFormat.USD,
       );
 
       const addressId = reward.addressId();


### PR DESCRIPTION
### What changed? Why?

This PR helps expose a `StakingRewardFormat` enum so that users can query for rewards based on both USD and Native formats. Earlier this wasn't exposed and user would have to rely on a string such as "usd" to query.

### Testing

```
>> npx ts-node --project tsconfig.json
> import { Coinbase, ExternalAddress, StakingRewardFormat } from "./src";
undefined
> let address = new ExternalAddress(Coinbase.networks.EthereumMainnet, "0x87Bf57c3d7B211a100ee4d00dee08435130A62fA");
undefined
```

```
>
undefined
> let rewards = await address.stakingRewards(Coinbase.assets.Eth, "2024-05-01T00:00:00Z", "2024-05-21T00:00:00Z", StakingRewardFormat.NATIVE);
undefined
> rewards.forEach(reward => console.log(reward.toString()));
StakingReward { date: '2024-05-01T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000003230829007739' usd_value: '0.01' conversion_price: '2971.419922' conversion_time: '2024-05-02T00:09:00.000Z' }
StakingReward { date: '2024-05-02T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001810463295078' usd_value: '0.01' conversion_price: '2984.810059' conversion_time: '2024-05-03T00:09:00.000Z' }
StakingReward { date: '2024-05-03T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001934541883308' usd_value: '0.01' conversion_price: '3103.570068' conversion_time: '2024-05-04T00:09:00.000Z' }
StakingReward { date: '2024-05-04T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.00000181602093757' usd_value: '0.01' conversion_price: '3116.860107' conversion_time: '2024-05-05T00:09:00.000Z' }
StakingReward { date: '2024-05-05T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001625176235078' usd_value: '0.01' conversion_price: '3144.01001' conversion_time: '2024-05-06T00:09:00.000Z' }
StakingReward { date: '2024-05-06T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001647341369184' usd_value: '0.01' conversion_price: '3070.639893' conversion_time: '2024-05-07T00:09:00.000Z' }
StakingReward { date: '2024-05-07T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001611182036692' usd_value: '0.01' conversion_price: '3016.580078' conversion_time: '2024-05-08T00:09:00.000Z' }
StakingReward { date: '2024-05-08T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001682407434134' usd_value: '0.01' conversion_price: '2976.870117' conversion_time: '2024-05-09T00:09:00.000Z' }
StakingReward { date: '2024-05-09T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001884275039332' usd_value: '0.01' conversion_price: '3033.02002' conversion_time: '2024-05-10T00:09:00.000Z' }
StakingReward { date: '2024-05-10T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001472758583644' usd_value: '0.01' conversion_price: '2908.919922' conversion_time: '2024-05-11T00:09:00.000Z' }
StakingReward { date: '2024-05-11T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001717129587009' usd_value: '0.01' conversion_price: '2914.639893' conversion_time: '2024-05-12T00:09:00.000Z' }
StakingReward { date: '2024-05-12T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001637753776374' usd_value: '0.01' conversion_price: '2929.969971' conversion_time: '2024-05-13T00:09:00.000Z' }
StakingReward { date: '2024-05-13T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001720645037146' usd_value: '0.01' conversion_price: '2944.370117' conversion_time: '2024-05-14T00:09:00.000Z' }
StakingReward { date: '2024-05-14T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000002046328146836' usd_value: '0.01' conversion_price: '2884.929932' conversion_time: '2024-05-15T00:09:00.000Z' }
StakingReward { date: '2024-05-15T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000002032340276719' usd_value: '0.01' conversion_price: '3035' conversion_time: '2024-05-16T00:09:00.000Z' }
StakingReward { date: '2024-05-16T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001806634901341' usd_value: '0.01' conversion_price: '2945.51001' conversion_time: '2024-05-17T00:09:00.000Z' }
StakingReward { date: '2024-05-17T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001591502534823' usd_value: '0.01' conversion_price: '3092.560059' conversion_time: '2024-05-18T00:09:00.000Z' }
StakingReward { date: '2024-05-18T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.00000169055851866' usd_value: '0.01' conversion_price: '3121.060059' conversion_time: '2024-05-19T00:09:00.000Z' }
StakingReward { date: '2024-05-19T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000001537556110879' usd_value: '0.01' conversion_price: '3074.280029' conversion_time: '2024-05-20T00:09:00.000Z' }
StakingReward { date: '2024-05-20T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.000002180781070852' usd_value: '0.01' conversion_price: '3680.570068' conversion_time: '2024-05-21T00:09:00.000Z' }
undefined
```

```
> let usdrewards = await address.stakingRewards(Coinbase.assets.Eth, "2024-05-01T00:00:00Z", "2024-05-21T00:00:00Z", StakingRewardFormat.USD);
undefined
> usdrewards.forEach(reward => console.log(reward.toString()));
StakingReward { date: '2024-05-01T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '2971.419922' conversion_time: '2024-05-02T00:09:00.000Z' }
StakingReward { date: '2024-05-02T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '2984.810059' conversion_time: '2024-05-03T00:09:00.000Z' }
StakingReward { date: '2024-05-03T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '3103.570068' conversion_time: '2024-05-04T00:09:00.000Z' }
StakingReward { date: '2024-05-04T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '3116.860107' conversion_time: '2024-05-05T00:09:00.000Z' }
StakingReward { date: '2024-05-05T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '3144.01001' conversion_time: '2024-05-06T00:09:00.000Z' }
StakingReward { date: '2024-05-06T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '3070.639893' conversion_time: '2024-05-07T00:09:00.000Z' }
StakingReward { date: '2024-05-07T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '3016.580078' conversion_time: '2024-05-08T00:09:00.000Z' }
StakingReward { date: '2024-05-08T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '2976.870117' conversion_time: '2024-05-09T00:09:00.000Z' }
StakingReward { date: '2024-05-09T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '3033.02002' conversion_time: '2024-05-10T00:09:00.000Z' }
StakingReward { date: '2024-05-10T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '2908.919922' conversion_time: '2024-05-11T00:09:00.000Z' }
StakingReward { date: '2024-05-11T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '2914.639893' conversion_time: '2024-05-12T00:09:00.000Z' }
StakingReward { date: '2024-05-12T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '2929.969971' conversion_time: '2024-05-13T00:09:00.000Z' }
StakingReward { date: '2024-05-13T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '2944.370117' conversion_time: '2024-05-14T00:09:00.000Z' }
StakingReward { date: '2024-05-14T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '2884.929932' conversion_time: '2024-05-15T00:09:00.000Z' }
StakingReward { date: '2024-05-15T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '3035' conversion_time: '2024-05-16T00:09:00.000Z' }
StakingReward { date: '2024-05-16T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '2945.51001' conversion_time: '2024-05-17T00:09:00.000Z' }
StakingReward { date: '2024-05-17T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '3092.560059' conversion_time: '2024-05-18T00:09:00.000Z' }
StakingReward { date: '2024-05-18T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '3121.060059' conversion_time: '2024-05-19T00:09:00.000Z' }
StakingReward { date: '2024-05-19T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '3074.280029' conversion_time: '2024-05-20T00:09:00.000Z' }
StakingReward { date: '2024-05-20T00:00:00.000Z' address: '0x87bf57c3d7b211a100ee4d00dee08435130a62fa' amount: '0.01' usd_value: '0.01' conversion_price: '3680.570068' conversion_time: '2024-05-21T00:09:00.000Z' }
undefined
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
