### PR TITLE
Return correlation ID from API Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `Coinbase.configure` method to allow for configuration of the SDK and marked constructor as deprecated.
+- Return correlation ID from APIError response
 
 ## [0.4.0] - 2024-09-06
 

--- a/src/coinbase/address/wallet_address.ts
+++ b/src/coinbase/address/wallet_address.ts
@@ -532,7 +532,9 @@ export class WalletAddress extends Address {
    * @param destination - The destination to get the address and network ID of.
    * @returns The address and network ID of the destination.
    */
-  private async getDestinationAddressAndNetwork(destination: Destination): Promise<[string, string]> {
+  private async getDestinationAddressAndNetwork(
+    destination: Destination,
+  ): Promise<[string, string]> {
     if (typeof destination !== "string" && destination.getNetworkId() !== this.getNetworkId()) {
       throw new ArgumentError("Transfer must be on the same Network");
     }

--- a/src/coinbase/api_error.ts
+++ b/src/coinbase/api_error.ts
@@ -16,6 +16,7 @@ export class APIError extends AxiosError {
   httpCode: number | null;
   apiCode: string | null;
   apiMessage: string | null;
+  correlationId: string | null;
 
   /**
    * Initializes a new APIError object.
@@ -29,11 +30,13 @@ export class APIError extends AxiosError {
     this.httpCode = error.response ? error.response.status : null;
     this.apiCode = null;
     this.apiMessage = null;
+    this.correlationId = null;
 
     if (error.response && error.response.data) {
       const body = error.response.data;
       this.apiCode = body.code;
       this.apiMessage = body.message;
+      this.correlationId = body.correlation_id;
     }
   }
 
@@ -108,7 +111,14 @@ export class APIError extends AxiosError {
    * @returns {string} a String representation of the APIError
    */
   toString() {
-    return `APIError{httpCode: ${this.httpCode}, apiCode: ${this.apiCode}, apiMessage: ${this.apiMessage}}`;
+    let payload = {} as Record<string, unknown>;
+
+    if (this.httpCode) payload.httpCode = this.httpCode;
+    if (this.apiCode) payload.apiCode = this.apiCode;
+    if (this.apiMessage) payload.apiMessage = this.apiMessage;
+    if (this.correlationId) payload.correlationId = this.correlationId;
+
+    return `${this.name}{${Object.entries(payload).map(([key, value]) => `${key}: ${value}`).join(", ")}}`;
   }
 }
 

--- a/src/coinbase/api_error.ts
+++ b/src/coinbase/api_error.ts
@@ -111,14 +111,16 @@ export class APIError extends AxiosError {
    * @returns {string} a String representation of the APIError
    */
   toString() {
-    let payload = {} as Record<string, unknown>;
+    const payload = {} as Record<string, unknown>;
 
     if (this.httpCode) payload.httpCode = this.httpCode;
     if (this.apiCode) payload.apiCode = this.apiCode;
     if (this.apiMessage) payload.apiMessage = this.apiMessage;
     if (this.correlationId) payload.correlationId = this.correlationId;
 
-    return `${this.name}{${Object.entries(payload).map(([key, value]) => `${key}: ${value}`).join(", ")}}`;
+    return `${this.name}{${Object.entries(payload)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(", ")}}`;
   }
 }
 

--- a/src/tests/address_test.ts
+++ b/src/tests/address_test.ts
@@ -171,9 +171,7 @@ describe("Address", () => {
       expect(
         Coinbase.apiClients.balanceHistory!.listAddressHistoricalBalance,
       ).toHaveBeenCalledTimes(1);
-      expect(
-        Coinbase.apiClients.balanceHistory!.listAddressHistoricalBalance,
-      ).toHaveBeenCalledWith(
+      expect(Coinbase.apiClients.balanceHistory!.listAddressHistoricalBalance).toHaveBeenCalledWith(
         address.getNetworkId(),
         address.getId(),
         Coinbase.assets.Usdc,
@@ -194,9 +192,7 @@ describe("Address", () => {
       expect(
         Coinbase.apiClients.balanceHistory!.listAddressHistoricalBalance,
       ).toHaveBeenCalledTimes(1);
-      expect(
-        Coinbase.apiClients.balanceHistory!.listAddressHistoricalBalance,
-      ).toHaveBeenCalledWith(
+      expect(Coinbase.apiClients.balanceHistory!.listAddressHistoricalBalance).toHaveBeenCalledWith(
         address.getNetworkId(),
         address.getId(),
         Coinbase.assets.Usdc,
@@ -219,9 +215,7 @@ describe("Address", () => {
       expect(
         Coinbase.apiClients.balanceHistory!.listAddressHistoricalBalance,
       ).toHaveBeenCalledTimes(1);
-      expect(
-        Coinbase.apiClients.balanceHistory!.listAddressHistoricalBalance,
-      ).toHaveBeenCalledWith(
+      expect(Coinbase.apiClients.balanceHistory!.listAddressHistoricalBalance).toHaveBeenCalledWith(
         address.getNetworkId(),
         address.getId(),
         Coinbase.assets.Usdc,
@@ -258,9 +252,7 @@ describe("Address", () => {
       expect(
         Coinbase.apiClients.balanceHistory!.listAddressHistoricalBalance,
       ).toHaveBeenCalledTimes(1);
-      expect(
-        Coinbase.apiClients.balanceHistory!.listAddressHistoricalBalance,
-      ).toHaveBeenCalledWith(
+      expect(Coinbase.apiClients.balanceHistory!.listAddressHistoricalBalance).toHaveBeenCalledWith(
         address.getNetworkId(),
         address.getId(),
         Coinbase.assets.Usdc,

--- a/src/tests/api_error_test.ts
+++ b/src/tests/api_error_test.ts
@@ -34,7 +34,8 @@ describe("APIError", () => {
     expect(apiError.httpCode).toBeNull();
     expect(apiError.apiCode).toBeNull();
     expect(apiError.apiMessage).toBeNull();
-    expect(apiError.toString()).toBe("APIError{httpCode: null, apiCode: null, apiMessage: null}");
+    expect(apiError.correlationId).toBeNull();
+    expect(apiError.toString()).toBe("APIError{}");
   });
 
   test("should create APIError with response data", () => {
@@ -44,6 +45,7 @@ describe("APIError", () => {
         data: {
           code: "invalid_wallet_id",
           message: "Invalid wallet ID",
+          correlation_id: "123",
         },
       },
     } as AxiosError;
@@ -53,8 +55,9 @@ describe("APIError", () => {
     expect(apiError.httpCode).toBe(400);
     expect(apiError.apiCode).toBe("invalid_wallet_id");
     expect(apiError.apiMessage).toBe("Invalid wallet ID");
+    expect(apiError.correlationId).toBe("123");
     expect(apiError.toString()).toBe(
-      "APIError{httpCode: 400, apiCode: invalid_wallet_id, apiMessage: Invalid wallet ID}",
+      "APIError{httpCode: 400, apiCode: invalid_wallet_id, apiMessage: Invalid wallet ID, correlationId: 123}",
     );
   });
 

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -104,13 +104,16 @@ describe("Coinbase SDK E2E Test", () => {
     console.log(`Second address balances: ${secondBalance}`);
 
     console.log("Fetching address transactions...");
-    const result = await (await unhydratedWallet.getDefaultAddress()).listTransactions({ limit: 1 });
+    const result = await (
+      await unhydratedWallet.getDefaultAddress()
+    ).listTransactions({ limit: 1 });
     expect(result?.transactions.length).toBeGreaterThan(0);
     console.log(`Fetched transactions: ${result?.transactions[0].toString()}`);
 
     console.log("Fetching address historical balances...");
-    const balance_result = await (await unhydratedWallet
-      .getDefaultAddress()).listHistoricalBalances({ assetId: Coinbase.assets.Eth, limit: 2 });
+    const balance_result = await (
+      await unhydratedWallet.getDefaultAddress()
+    ).listHistoricalBalances({ assetId: Coinbase.assets.Eth, limit: 2 });
     expect(balance_result?.historicalBalances.length).toBeGreaterThan(0);
     console.log(
       `First eth historical balance: ${balance_result?.historicalBalances[0].amount.toString()}`,

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -567,7 +567,9 @@ describe("Wallet Class", () => {
     beforeEach(async () => {
       expectedInvocation = ContractInvocation.fromModel(VALID_SIGNED_CONTRACT_INVOCATION_MODEL);
 
-      (await wallet.getDefaultAddress()).invokeContract = jest.fn().mockResolvedValue(expectedInvocation);
+      (await wallet.getDefaultAddress()).invokeContract = jest
+        .fn()
+        .mockResolvedValue(expectedInvocation);
     });
 
     it("successfully invokes a contract on the default address", async () => {
@@ -694,7 +696,9 @@ describe("Wallet Class", () => {
 
     describe("#getDefaultAddress", () => {
       it("should return the correct default address", async () => {
-        expect((await wallet.getDefaultAddress()).getId()).toBe(walletModel.default_address!.address_id);
+        expect((await wallet.getDefaultAddress()).getId()).toBe(
+          walletModel.default_address!.address_id,
+        );
       });
     });
 
@@ -935,7 +939,9 @@ describe("Wallet Class", () => {
     it("should throw an error when walletId is not provided", async () => {
       const walletData = seedWallet.export();
       walletData.walletId = "";
-      await expect(async () => await Wallet.import(walletData)).rejects.toThrow("Wallet ID must be provided");
+      await expect(async () => await Wallet.import(walletData)).rejects.toThrow(
+        "Wallet ID must be provided",
+      );
     });
   });
 


### PR DESCRIPTION
### What changed? Why?
This makes it so that the correlation ID from the API Error is returned in the API Error response. This will help in debugging issues more easily as we can quickly link together associated requests.

### How has this been tested?
* Running the SDK locally against deployed API

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
