### PR TITLE
Fix Asset toAtomicAmount to not return scientific notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Add SOL asset support
 - Fix a bug where large numbers were being returned in scientific notation
 
+### Breaking
+- `Asset#toAtomicAmount` now returns a BigInt instead of a Decimal
+  
 ## [0.5.0] - 2024-09-11
 
 - Add Arbitrum-Mainnet support for Native transfers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `deployToken` method to `WalletAddress` and `Wallet` to deploy an ERC20, updated `SmartContract` class to support deployment and fetching contract details
 - Add SOL asset support
+- Fix a bug where large numbers were being returned in scientific notation
 
 ## [0.5.0] - 2024-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+### Added
 - Add `deployToken` method to `WalletAddress` and `Wallet` to deploy an ERC20, updated `SmartContract` class to support deployment and fetching contract details
 - Add SOL asset support
 - Fix a bug where large numbers were being returned in scientific notation

--- a/src/coinbase/asset.ts
+++ b/src/coinbase/asset.ts
@@ -112,17 +112,19 @@ export class Asset {
    * @param wholeAmount - The whole amount to convert to atomic units.
    * @returns The amount in atomic units
    */
-  toAtomicAmount(wholeAmount: Decimal): Decimal {
-    return wholeAmount.times(new Decimal(10).pow(this.decimals));
+  toAtomicAmount(wholeAmount: Decimal): bigint {
+    const atomicAmount = wholeAmount.times(new Decimal(10).pow(this.decimals));
+    return BigInt(atomicAmount.toFixed());
   }
+
   /**
    * Converts the amount of the Asset from atomic to whole units.
    *
-   * @param wholeAmount - The atomic amount to convert to whole units.
+   * @param atomicAmount - The atomic amount to convert to whole units.
    * @returns The amount in atomic units
    */
-  fromAtomicAmount(wholeAmount: Decimal): Decimal {
-    return wholeAmount.dividedBy(new Decimal(10).pow(this.decimals));
+  fromAtomicAmount(atomicAmount: Decimal): Decimal {
+    return atomicAmount.dividedBy(new Decimal(10).pow(this.decimals));
   }
 
   /**

--- a/src/tests/asset_test.ts
+++ b/src/tests/asset_test.ts
@@ -47,7 +47,7 @@ describe("Asset", () => {
     });
   });
 
-  describe(".toString", () => {
+  describe("#toString", () => {
     it("should return the assetId", () => {
       const asset = Asset.fromModel({
         asset_id: "eth",
@@ -77,7 +77,7 @@ describe("Asset", () => {
     });
   });
 
-  describe(".toAtomicAmount", () => {
+  describe("#toAtomicAmount", () => {
     it("should return the atomic amount", () => {
       const asset = Asset.fromModel({
         asset_id: "eth",

--- a/src/tests/asset_test.ts
+++ b/src/tests/asset_test.ts
@@ -1,3 +1,4 @@
+import Decimal from "decimal.js";
 import { Coinbase } from "../coinbase/coinbase";
 import { GWEI_DECIMALS } from "../coinbase/constants";
 import { Asset } from "./../coinbase/asset";
@@ -73,6 +74,31 @@ describe("Asset", () => {
       it("should return the assetId", () => {
         expect(Asset.primaryDenomination("other")).toEqual("other");
       });
+    });
+  });
+
+  describe(".toAtomicAmount", () => {
+    it("should return the atomic amount", () => {
+      const asset = Asset.fromModel({
+        asset_id: "eth",
+        network_id: Coinbase.networks.BaseSepolia,
+        contract_address: "contractAddress",
+        decimals: 18,
+      });
+      const atomicAmount = asset.toAtomicAmount(new Decimal(1.23));
+      expect(atomicAmount).toEqual(BigInt(1230000000000000000));
+    });
+
+    it("should handle large numbers without using scientific notation", () => {
+      const asset = Asset.fromModel({
+        asset_id: "eth",
+        network_id: Coinbase.networks.BaseSepolia,
+        contract_address: "contractAddress",
+        decimals: 18,
+      });
+      const atomicAmount = asset.toAtomicAmount(new Decimal(2000));
+      expect(atomicAmount).toEqual(BigInt(2000000000000000000000));
+      expect(atomicAmount.toString()).not.toContain("e");
     });
   });
 });


### PR DESCRIPTION
### What changed? Why?
Earlier, `toAtomicAmount(new Decimal(1000))` where decimals was 18 would result in 2e+21, which then got serialized as a string and failed on our backend as an `invalid_amount`. This PR changes `toAtomicAmount` to return a bigint which gets serialized correctly.

Testing:
- Unit tests added
- Confirmed the unit test in wallet_address_test fails in v0.6.0 branch but succeeds with the rest of the changes in this PR
- Tested end to end in prod with this command successfully:
```
const transfer = addr.createTransfer({amount: 1000, assetId: "0xfa32823cf44fCE33131312e973C72362CE1D9C55", destination: '0x339c1ca0c2bB9522D4d61C6562B2d49021f9a0C0'});
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
We're still returning a numeric but this is technically backward-incompatible. We expect external usages of this function to be low and it to be primarily used by our other classes. 