### PR TITLE
Fix getAbi return type on smart_contract

### DIFF
--- a/src/coinbase/smart_contract.ts
+++ b/src/coinbase/smart_contract.ts
@@ -175,7 +175,7 @@ export class SmartContract {
    *
    * @returns The ABI as a JSON-encoded string.
    */
-  public getAbi(): string {
+  public getAbi(): object {
     return JSON.parse(this.model.abi);
   }
 


### PR DESCRIPTION
### What changed? Why?
We had updated to use `JSON.parse` but I forgot to go from string -> object

Tested invokeContract locally successfully now by doing: 
```
await addr.invokeContract({ contractAddress: sc.getContractAddress(), method: 'transfer', args: { to: newAddress.getId(), value: '1000000000000000000000' }, abi: sc.getAbi() });
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
