### PR TITLE
fix: Make register-basename.js Quickstart Template Executable

### DIFF
--- a/quickstart-template/register-basename.js
+++ b/quickstart-template/register-basename.js
@@ -145,7 +145,7 @@ async function fetchWalletAndLoadSeed(walletId, seedFilePath) {
   }
 }
 
-async () => {
+(async () => {
   try {
     const { BASE_NAME, WALLET_ID, SEED_FILE_PATH } = process.env;
 
@@ -165,4 +165,4 @@ async () => {
   } catch (error) {
     console.error(`Error in registering a Basename for my wallet: `, error);
   }
-};
+})();


### PR DESCRIPTION
### What changed? Why?
- Make the `quickstart-templates/register-basename.js` executable 

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
