### PR TITLE
Webhook update hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ## [0.8.1] - 2024-10-09
+
 ### Fixed
 - Fixed a bug that overwrites existing webhook notification URI when only updating a webhook's addresses
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## [0.8.1] - 2024-10-09
+### Fixed
+- Fixed a bug that overwrites existing webhook notification URI when only updating a webhook's addresses
+
 ## [0.8.0] - 2024-10-04
 
 ### Added

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   maxWorkers: 1,
   coverageThreshold: {
     "./src/coinbase/**": {
-      branches: 77,
+      branches: 75,
       functions: 85,
       statements: 85,
       lines: 85,

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   maxWorkers: 1,
   coverageThreshold: {
     "./src/coinbase/**": {
-      branches: 75,
+      branches: 77,
       functions: 85,
       statements: 85,
       lines: 85,

--- a/src/coinbase/webhook.ts
+++ b/src/coinbase/webhook.ts
@@ -185,10 +185,13 @@ export class Webhook {
     notificationUri,
     eventTypeFilter,
   }: UpdateWebhookOptions): Promise<Webhook> {
+    const finalNotificationUri = notificationUri ?? this.getNotificationURI();
+    const finalEventTypeFilter = eventTypeFilter ?? this.getEventTypeFilter();
+
     const result = await Coinbase.apiClients.webhook!.updateWebhook(this.getId()!, {
-      notification_uri: notificationUri,
+      notification_uri: finalNotificationUri,
       event_filters: this.getEventFilters()!,
-      event_type_filter: eventTypeFilter,
+      event_type_filter: finalEventTypeFilter,
     });
 
     this.model = result.data;

--- a/src/tests/webhook_test.ts
+++ b/src/tests/webhook_test.ts
@@ -206,6 +206,10 @@ describe("Webhook", () => {
       expect(Coinbase.apiClients.webhook!.updateWebhook).toHaveBeenCalledWith("test-id", {
         notification_uri: "https://new-url.com/callback",
         event_filters: [{ contract_address: "0x...", from_address: "0x...", to_address: "0x..." }],
+        event_type_filter: {
+          addresses: ["0xa55C5950F7A3C42Fa5799B2Cac0e455774a07382"],
+          wallet_id: "w1",
+        },
       });
 
       expect(webhook.getNotificationURI()).toBe("https://new-url.com/callback");

--- a/src/tests/webhook_test.ts
+++ b/src/tests/webhook_test.ts
@@ -214,6 +214,19 @@ describe("Webhook", () => {
 
       expect(webhook.getNotificationURI()).toBe("https://new-url.com/callback");
     });
+    it("should update the webhook address list only", async () => {
+      const webhook = Webhook.init(mockModel);
+      await webhook.update({ eventTypeFilter: { addresses: ["0x1..", "0x2.."] } });
+
+      expect(Coinbase.apiClients.webhook!.updateWebhook).toHaveBeenCalledWith("test-id", {
+        notification_uri: "https://example.com/callback",
+        event_filters: [{ contract_address: "0x...", from_address: "0x...", to_address: "0x..." }],
+        event_type_filter: { addresses: ["0x1..", "0x2.."] },
+      });
+
+      expect(webhook.getNotificationURI()).toBe("https://example.com/callback");
+      expect(webhook.getEventTypeFilter()?.addresses).toEqual(["0x1..", "0x2.."]);
+    });
     it("should update both the webhook notification URI and the list of addresses monitoring", async () => {
       const mockModel: WebhookModel = {
         id: "test-id",


### PR DESCRIPTION
### What changed? Why?

Fixed a bug that overwrites existing webhook notification URI when only updating a webhook's addresses
```
 let wh = await Webhook.create({ networkId: "base-mainnet", notificationUri: "https://www.google.com/callback", eventType: "wallet_activity",  eventTypeFilter: {addresses: ["0xa55C5950F7A3C42Fa5799B2Cac0e455774a07382"], wallet_id: "w1"}, eventFilters: [{ contract_address: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" }], signatureHeader: "optional-signature-string"});
undefined
> wh.update({eventTypeFilter: {addresses:["0x40A28c0fCc0BE09400bB89CdF556Cd8C4eF1c165","0x6f03b3Df22F0C57A4477EEAc3a49c2Bc4EAe2206"]}})
Promise {
  <pending>,
  [Symbol(async_id_symbol)]: 136,
  [Symbol(trigger_async_id_symbol)]: 4
}
> wh
Webhook {
  model: {
    created_at: '2024-10-09T18:47:59.182Z',
    event_filters: [ [Object] ],
    event_type: 'wallet_activity',
    event_type_filter: { addresses: [Array], wallet_id: 'w1' },
    id: '6706cfdf1f3dda7f7fc8f6d2',
    network_id: 'base-mainnet',
    notification_uri: 'https://www.google.com/callback',
    updated_at: '2024-10-09T18:48:13.901Z'
  }
}

 wh.update({notificationUri: "https://abc.com/callback"})
Promise {
  <pending>,
  [Symbol(async_id_symbol)]: 563,
  [Symbol(trigger_async_id_symbol)]: 4
}
> wh.toString()
`Webhook { id: '670706861f3dda7f7fc8f6d9', networkId: 'base-mainnet', eventType: 'wallet_activity', eventFilter: [{"contract_address":"0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"}], eventTypeFilter: {"addresses":["0x40a28c0fcc0be09400bb89cdf556cd8c4ef1c165","0x6f03b3df22f0c57a4477eeac3a49c2bc4eae2206"],"wallet_id":"w1"}, notificationUri: 'https://abc.com/callback', signatureHeader: 'undefined' }`

```

ref PR https://github.com/coinbase/coinbase-sdk-nodejs/pull/288 

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
