### PR TITLE
Updating readContract args to take in any for the value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## [0.9.1] - 2024-10-18
+
+### Fixed
+- Fixed a bug where readContract was not working for nested types
+
 ## [0.9.0] - 2024-10-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "ISC",
   "description": "Coinbase Platform SDK",
   "repository": "https://github.com/coinbase/coinbase-sdk-nodejs",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/quickstart-template/package.json
+++ b/quickstart-template/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@solana/web3.js": "^2.0.0-rc.1",
     "bs58": "^6.0.0",
-    "@coinbase/coinbase-sdk": "^0.9.0",
+    "@coinbase/coinbase-sdk": "^0.9.1",
     "csv-parse": "^5.5.6",
     "csv-writer": "^1.6.0",
     "viem": "^2.21.6"

--- a/src/coinbase/read_contract.ts
+++ b/src/coinbase/read_contract.ts
@@ -114,7 +114,7 @@ function parseSolidityValue<T>(solidityValue: SolidityValue): T {
 export async function readContract<
   TAbi extends Abi | undefined,
   TFunctionName extends TAbi extends Abi ? ContractFunctionName<TAbi, "view" | "pure"> : string,
-  TArgs extends Record<string, string>,
+  TArgs extends Record<string, any>,
 >(params: {
   networkId: string;
   contractAddress: `0x${string}`;
@@ -128,7 +128,7 @@ export async function readContract<
         Extract<TFunctionName, ContractFunctionName<TAbi, "view" | "pure">>,
         TArgs
       >
-    : unknown
+    : any
 > {
   const response = await Coinbase.apiClients.smartContract!.readContract(
     params.networkId,

--- a/src/coinbase/read_contract.ts
+++ b/src/coinbase/read_contract.ts
@@ -110,7 +110,7 @@ function parseSolidityValue<T>(solidityValue: SolidityValue): T {
  * @param {TFunctionName} params.method - The contract method to call.
  * @param {TArgs} params.args - The arguments for the contract method.
  * @param {TAbi} [params.abi] - The contract ABI (optional).
- * @returns {Promise<any>} The result of the contract call.
+ * @returns {Promise<TAbi extends Abi ? ContractFunctionReturnType<TAbi, Extract<TFunctionName, ContractFunctionName<TAbi, "view" | "pure">>, TArgs> : unknown>} The result of the contract call.
  */
 export async function readContract<
   TAbi extends Abi | undefined,
@@ -148,6 +148,6 @@ export async function readContract<
           Extract<TFunctionName, ContractFunctionName<TAbi, "view" | "pure">>,
           TArgs
         >
-      : unknown
+      : any
   >(response.data);
 }

--- a/src/coinbase/read_contract.ts
+++ b/src/coinbase/read_contract.ts
@@ -110,7 +110,7 @@ function parseSolidityValue<T>(solidityValue: SolidityValue): T {
  * @param {TFunctionName} params.method - The contract method to call.
  * @param {TArgs} params.args - The arguments for the contract method.
  * @param {TAbi} [params.abi] - The contract ABI (optional).
- * @returns {Promise<TAbi extends Abi ? ContractFunctionReturnType<TAbi, Extract<TFunctionName, ContractFunctionName<TAbi, "view" | "pure">>, TArgs> : unknown>} The result of the contract call.
+ * @returns {Promise<any>} The result of the contract call.
  */
 export async function readContract<
   TAbi extends Abi | undefined,

--- a/src/coinbase/read_contract.ts
+++ b/src/coinbase/read_contract.ts
@@ -1,3 +1,4 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
 import type { Abi } from "abitype";
 import { Coinbase } from "./coinbase";
 import { ContractFunctionName } from "viem";
@@ -109,7 +110,7 @@ function parseSolidityValue<T>(solidityValue: SolidityValue): T {
  * @param {TFunctionName} params.method - The contract method to call.
  * @param {TArgs} params.args - The arguments for the contract method.
  * @param {TAbi} [params.abi] - The contract ABI (optional).
- * @returns {Promise<unknown>} The result of the contract call.
+ * @returns {Promise<any>} The result of the contract call.
  */
 export async function readContract<
   TAbi extends Abi | undefined,

--- a/src/coinbase/types/contract.ts
+++ b/src/coinbase/types/contract.ts
@@ -12,7 +12,7 @@ import { ContractFunctionName } from "viem";
  * Each parameter name becomes a key in the resulting dictionary, with a string value.
  */
 type AbiParametersToDictionary<T extends readonly AbiParameter[]> = {
-  [K in T[number]["name"] as K extends string ? K : never]: string;
+  [K in T[number]["name"] as K extends string ? K : any]: string;
 };
 
 /**
@@ -38,9 +38,9 @@ type MatchArgsToFunction<
     ? TFunctions extends AbiFunction
       ? MatchesParams<TArgs, AbiParametersToDictionary<TFunctions["inputs"]>> extends true
         ? TFunctions
-        : never
-      : never
-    : never;
+        : any
+      : any
+    : any;
 
 /**
  * Determines the return type of a contract function based on the ABI, function name, and arguments.
@@ -68,6 +68,6 @@ export type ContractFunctionReturnType<
           : TOutputs extends readonly [infer TOutput]
             ? TOutput
             : TOutputs
-        : never
-      : unknown
-    : unknown;
+        : any
+      : any
+    : any;


### PR DESCRIPTION
### What changed? Why?
The current Record<String, String> interface for args is too strict, as it's possible for some read functions to take in a nested type. We have a potential fix for `args` that works with nested types but it needs more testing. This PR instead sets it to `any`, which is much more permissive. It still however gives proper type-inference and shows the type that will be returned when a match occurs.

I changed from unknowns and never to be `any` which is to be more permissive. Until we have rock solid type-inference, this feels more appropriate.

### Testing
- Existing unit tests pass
- The bug that a user hit due to Record<String, String> now works without them having to do `as unknown as Record<String, String>` which was the temporary fix.
- My local e2e test script correctly does type-inference in my IDE, and the values returned from the script are correct.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
