### PR TITLE
feat: Use async faucet transactions and support wait/reload 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add support for async faucet transactions i.e. using `faucetTx.wait()` to wait for the transaction to be confirmed.
+
 ## [0.9.1] - 2024-10-18
 
 ### Fixed

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -596,6 +596,50 @@ export interface CreateContractInvocationRequest {
 /**
  * 
  * @export
+ * @interface CreateFundOperationRequest
+ */
+export interface CreateFundOperationRequest {
+    /**
+     * The amount of the asset to fund the address with in atomic units.
+     * @type {string}
+     * @memberof CreateFundOperationRequest
+     */
+    'amount': string;
+    /**
+     * The ID of the asset to fund the address with.
+     * @type {string}
+     * @memberof CreateFundOperationRequest
+     */
+    'asset_id': string;
+    /**
+     * The Optional ID of the fund quote to fund the address with. If omitted we will generate a quote and immediately execute it.
+     * @type {string}
+     * @memberof CreateFundOperationRequest
+     */
+    'fund_quote_id'?: string;
+}
+/**
+ * 
+ * @export
+ * @interface CreateFundQuoteRequest
+ */
+export interface CreateFundQuoteRequest {
+    /**
+     * The amount of the asset to fund the address with in atomic units.
+     * @type {string}
+     * @memberof CreateFundQuoteRequest
+     */
+    'amount': string;
+    /**
+     * The ID of the asset to fund the address with.
+     * @type {string}
+     * @memberof CreateFundQuoteRequest
+     */
+    'asset_id': string;
+}
+/**
+ * 
+ * @export
  * @interface CreatePayloadSignatureRequest
  */
 export interface CreatePayloadSignatureRequest {
@@ -848,6 +892,25 @@ export interface CreateWebhookRequest {
 
 
 /**
+ * An amount in cryptocurrency
+ * @export
+ * @interface CryptoAmount
+ */
+export interface CryptoAmount {
+    /**
+     * The amount of the crypto in atomic units
+     * @type {string}
+     * @memberof CryptoAmount
+     */
+    'amount': string;
+    /**
+     * 
+     * @type {Asset}
+     * @memberof CryptoAmount
+     */
+    'asset': Asset;
+}
+/**
  * 
  * @export
  * @interface DeploySmartContractRequest
@@ -1033,6 +1096,57 @@ export interface ERC721TransferEvent {
 /**
  * 
  * @export
+ * @interface EthereumTokenTransfer
+ */
+export interface EthereumTokenTransfer {
+    /**
+     * 
+     * @type {string}
+     * @memberof EthereumTokenTransfer
+     */
+    'contract_address': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof EthereumTokenTransfer
+     */
+    'from_address': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof EthereumTokenTransfer
+     */
+    'to_address': string;
+    /**
+     * The value of the transaction in atomic units of the token being transfer for ERC20 or ERC1155 contracts.
+     * @type {string}
+     * @memberof EthereumTokenTransfer
+     */
+    'value'?: string;
+    /**
+     * The ID of ERC721 or ERC1155 token being transferred.
+     * @type {string}
+     * @memberof EthereumTokenTransfer
+     */
+    'token_id'?: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof EthereumTokenTransfer
+     */
+    'log_index': number;
+    /**
+     * 
+     * @type {TokenTransferType}
+     * @memberof EthereumTokenTransfer
+     */
+    'token_transfer_type': TokenTransferType;
+}
+
+
+/**
+ * 
+ * @export
  * @interface EthereumTransaction
  */
 export interface EthereumTransaction {
@@ -1120,6 +1234,12 @@ export interface EthereumTransaction {
      * @memberof EthereumTransaction
      */
     'transaction_access_list'?: EthereumTransactionAccessList;
+    /**
+     * 
+     * @type {Array<EthereumTokenTransfer>}
+     * @memberof EthereumTransaction
+     */
+    'token_transfers'?: Array<EthereumTokenTransfer>;
     /**
      * 
      * @type {Array<EthereumTransactionFlattenedTrace>}
@@ -1371,6 +1491,12 @@ export interface FaucetTransaction {
      * @memberof FaucetTransaction
      */
     'transaction_link': string;
+    /**
+     * 
+     * @type {Transaction}
+     * @memberof FaucetTransaction
+     */
+    'transaction': Transaction;
 }
 /**
  * 
@@ -1510,6 +1636,194 @@ export interface FetchStakingRewardsRequest {
 }
 
 
+/**
+ * An amount in fiat currency
+ * @export
+ * @interface FiatAmount
+ */
+export interface FiatAmount {
+    /**
+     * The amount of the fiat in whole units.
+     * @type {string}
+     * @memberof FiatAmount
+     */
+    'amount': string;
+    /**
+     * The currency of the fiat
+     * @type {string}
+     * @memberof FiatAmount
+     */
+    'currency': string;
+}
+/**
+ * An operation to fund a wallet with crypto
+ * @export
+ * @interface FundOperation
+ */
+export interface FundOperation {
+    /**
+     * The ID of the fund operation
+     * @type {string}
+     * @memberof FundOperation
+     */
+    'fund_operation_id': string;
+    /**
+     * The ID of the blockchain network
+     * @type {string}
+     * @memberof FundOperation
+     */
+    'network_id': string;
+    /**
+     * The ID of the wallet that will receive the crypto
+     * @type {string}
+     * @memberof FundOperation
+     */
+    'wallet_id': string;
+    /**
+     * The ID of the address that will receive the crypto
+     * @type {string}
+     * @memberof FundOperation
+     */
+    'address_id': string;
+    /**
+     * 
+     * @type {CryptoAmount}
+     * @memberof FundOperation
+     */
+    'crypto_amount': CryptoAmount;
+    /**
+     * 
+     * @type {FiatAmount}
+     * @memberof FundOperation
+     */
+    'fiat_amount': FiatAmount;
+    /**
+     * 
+     * @type {FundOperationFees}
+     * @memberof FundOperation
+     */
+    'fees': FundOperationFees;
+    /**
+     * The status of the fund operation
+     * @type {string}
+     * @memberof FundOperation
+     */
+    'status': FundOperationStatusEnum;
+}
+
+export const FundOperationStatusEnum = {
+    Pending: 'pending',
+    Complete: 'complete',
+    Failed: 'failed'
+} as const;
+
+export type FundOperationStatusEnum = typeof FundOperationStatusEnum[keyof typeof FundOperationStatusEnum];
+
+/**
+ * The fees for a fund operation.
+ * @export
+ * @interface FundOperationFees
+ */
+export interface FundOperationFees {
+    /**
+     * 
+     * @type {FiatAmount}
+     * @memberof FundOperationFees
+     */
+    'buy_fee': FiatAmount;
+    /**
+     * 
+     * @type {CryptoAmount}
+     * @memberof FundOperationFees
+     */
+    'transfer_fee': CryptoAmount;
+}
+/**
+ * Paginated list of fund operations
+ * @export
+ * @interface FundOperationList
+ */
+export interface FundOperationList {
+    /**
+     * 
+     * @type {Array<FundOperation>}
+     * @memberof FundOperationList
+     */
+    'data': Array<FundOperation>;
+    /**
+     * True if this list has another page of items after this one that can be fetched.
+     * @type {boolean}
+     * @memberof FundOperationList
+     */
+    'has_more': boolean;
+    /**
+     * The page token to be used to fetch the next page.
+     * @type {string}
+     * @memberof FundOperationList
+     */
+    'next_page': string;
+    /**
+     * The total number of fund operations
+     * @type {number}
+     * @memberof FundOperationList
+     */
+    'total_count': number;
+}
+/**
+ * A quote for a fund operation
+ * @export
+ * @interface FundQuote
+ */
+export interface FundQuote {
+    /**
+     * The ID of the fund quote
+     * @type {string}
+     * @memberof FundQuote
+     */
+    'fund_quote_id': string;
+    /**
+     * The ID of the blockchain network
+     * @type {string}
+     * @memberof FundQuote
+     */
+    'network_id': string;
+    /**
+     * The ID of the wallet that will receive the crypto
+     * @type {string}
+     * @memberof FundQuote
+     */
+    'wallet_id': string;
+    /**
+     * The ID of the address that will receive the crypto
+     * @type {string}
+     * @memberof FundQuote
+     */
+    'address_id': string;
+    /**
+     * 
+     * @type {CryptoAmount}
+     * @memberof FundQuote
+     */
+    'crypto_amount': CryptoAmount;
+    /**
+     * 
+     * @type {FiatAmount}
+     * @memberof FundQuote
+     */
+    'fiat_amount': FiatAmount;
+    /**
+     * The time at which the quote expires
+     * @type {string}
+     * @memberof FundQuote
+     */
+    'expires_at': string;
+    /**
+     * 
+     * @type {FundOperationFees}
+     * @memberof FundQuote
+     */
+    'fees': FundOperationFees;
+}
 /**
  * 
  * @export
@@ -1718,6 +2032,104 @@ export const NetworkIdentifier = {
 export type NetworkIdentifier = typeof NetworkIdentifier[keyof typeof NetworkIdentifier];
 
 
+/**
+ * A representation of an onchain stored name from name systems i.e. ENS or Basenames
+ * @export
+ * @interface OnchainName
+ */
+export interface OnchainName {
+    /**
+     * The ID for the NFT related to this name
+     * @type {string}
+     * @memberof OnchainName
+     */
+    'token_id': string;
+    /**
+     * The onchain address of the owner of the name
+     * @type {string}
+     * @memberof OnchainName
+     */
+    'owner_address': string;
+    /**
+     * The onchain address of the manager of the name
+     * @type {string}
+     * @memberof OnchainName
+     */
+    'manager_address': string;
+    /**
+     * The primary onchain address of the name
+     * @type {string}
+     * @memberof OnchainName
+     */
+    'primary_address'?: string;
+    /**
+     * The readable format for the name in complete form
+     * @type {string}
+     * @memberof OnchainName
+     */
+    'domain': string;
+    /**
+     * The visual representation attached to this name
+     * @type {string}
+     * @memberof OnchainName
+     */
+    'avatar'?: string;
+    /**
+     * The ID of the blockchain network
+     * @type {string}
+     * @memberof OnchainName
+     */
+    'network_id': string;
+    /**
+     * The expiration date for this name\'s ownership
+     * @type {string}
+     * @memberof OnchainName
+     */
+    'expires_at': string;
+    /**
+     * The metadata attached to this name
+     * @type {{ [key: string]: string; }}
+     * @memberof OnchainName
+     */
+    'text_records'?: { [key: string]: string; };
+    /**
+     * Whether this name is the primary name for the owner (This is when the ETH coin address for this name is equal to the primary_address. More info here https://docs.ens.domains/ensip/19)
+     * @type {boolean}
+     * @memberof OnchainName
+     */
+    'is_primary': boolean;
+}
+/**
+ * A list of onchain events with pagination information
+ * @export
+ * @interface OnchainNameList
+ */
+export interface OnchainNameList {
+    /**
+     * A list of onchain name objects
+     * @type {Array<OnchainName>}
+     * @memberof OnchainNameList
+     */
+    'data': Array<OnchainName>;
+    /**
+     * True if this list has another page of items after this one that can be fetched.
+     * @type {boolean}
+     * @memberof OnchainNameList
+     */
+    'has_more'?: boolean;
+    /**
+     * The page token to be used to fetch the next page.
+     * @type {string}
+     * @memberof OnchainNameList
+     */
+    'next_page': string;
+    /**
+     * The total number of payload signatures for the address.
+     * @type {number}
+     * @memberof OnchainNameList
+     */
+    'total_count'?: number;
+}
 /**
  * A payload signed by an address.
  * @export
@@ -2627,6 +3039,22 @@ export interface TokenContractOptions {
      */
     'total_supply': string;
 }
+/**
+ * The type of the token transfer.
+ * @export
+ * @enum {string}
+ */
+
+export const TokenTransferType = {
+    Erc20: 'erc20',
+    Erc721: 'erc721',
+    Erc1155: 'erc1155',
+    Unknown: 'unknown'
+} as const;
+
+export type TokenTransferType = typeof TokenTransferType[keyof typeof TokenTransferType];
+
+
 /**
  * A trade of an asset to another asset
  * @export
@@ -3688,6 +4116,7 @@ export const AddressesApiAxiosParamCreator = function (configuration?: Configura
          * @param {string} addressId The onchain address of the address that is being fetched.
          * @param {string} [assetId] The ID of the asset to transfer from the faucet.
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         requestFaucetFunds: async (walletId: string, addressId: string, assetId?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
@@ -3860,6 +4289,7 @@ export const AddressesApiFp = function(configuration?: Configuration) {
          * @param {string} addressId The onchain address of the address that is being fetched.
          * @param {string} [assetId] The ID of the asset to transfer from the faucet.
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         async requestFaucetFunds(walletId: string, addressId: string, assetId?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FaucetTransaction>> {
@@ -3980,6 +4410,7 @@ export const AddressesApiFactory = function (configuration?: Configuration, base
          * @param {string} addressId The onchain address of the address that is being fetched.
          * @param {string} [assetId] The ID of the asset to transfer from the faucet.
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         requestFaucetFunds(walletId: string, addressId: string, assetId?: string, options?: RawAxiosRequestConfig): AxiosPromise<FaucetTransaction> {
@@ -4096,6 +4527,7 @@ export interface AddressesApiInterface {
      * @param {string} addressId The onchain address of the address that is being fetched.
      * @param {string} [assetId] The ID of the asset to transfer from the faucet.
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      * @memberof AddressesApiInterface
      */
@@ -4228,6 +4660,7 @@ export class AddressesApi extends BaseAPI implements AddressesApiInterface {
      * @param {string} addressId The onchain address of the address that is being fetched.
      * @param {string} [assetId] The ID of the asset to transfer from the faucet.
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      * @memberof AddressesApi
      */
@@ -5228,6 +5661,48 @@ export const ExternalAddressesApiAxiosParamCreator = function (configuration?: C
             };
         },
         /**
+         * Get the status of a faucet transaction
+         * @summary Get the status of a faucet transaction
+         * @param {string} networkId The ID of the blockchain network
+         * @param {string} addressId The ID of the address to fetch the faucet transaction for
+         * @param {string} txHash The hash of the faucet transaction
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getFaucetTransaction: async (networkId: string, addressId: string, txHash: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'networkId' is not null or undefined
+            assertParamExists('getFaucetTransaction', 'networkId', networkId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('getFaucetTransaction', 'addressId', addressId)
+            // verify required parameter 'txHash' is not null or undefined
+            assertParamExists('getFaucetTransaction', 'txHash', txHash)
+            const localVarPath = `/v1/networks/{network_id}/addresses/{address_id}/faucet/{tx_hash}`
+                .replace(`{${"network_id"}}`, encodeURIComponent(String(networkId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)))
+                .replace(`{${"tx_hash"}}`, encodeURIComponent(String(txHash)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * List all of the balances of an external address
          * @summary Get the balances of an external address
          * @param {string} networkId The ID of the blockchain network
@@ -5276,10 +5751,11 @@ export const ExternalAddressesApiAxiosParamCreator = function (configuration?: C
          * @param {string} networkId The ID of the wallet the address belongs to.
          * @param {string} addressId The onchain address of the address that is being fetched.
          * @param {string} [assetId] The ID of the asset to transfer from the faucet.
+         * @param {boolean} [skipWait] Whether to skip waiting for the transaction to be mined. This will become the default behavior in the future.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        requestExternalFaucetFunds: async (networkId: string, addressId: string, assetId?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        requestExternalFaucetFunds: async (networkId: string, addressId: string, assetId?: string, skipWait?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'networkId' is not null or undefined
             assertParamExists('requestExternalFaucetFunds', 'networkId', networkId)
             // verify required parameter 'addressId' is not null or undefined
@@ -5300,6 +5776,10 @@ export const ExternalAddressesApiAxiosParamCreator = function (configuration?: C
 
             if (assetId !== undefined) {
                 localVarQueryParameter['asset_id'] = assetId;
+            }
+
+            if (skipWait !== undefined) {
+                localVarQueryParameter['skip_wait'] = skipWait;
             }
 
 
@@ -5339,6 +5819,21 @@ export const ExternalAddressesApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
+         * Get the status of a faucet transaction
+         * @summary Get the status of a faucet transaction
+         * @param {string} networkId The ID of the blockchain network
+         * @param {string} addressId The ID of the address to fetch the faucet transaction for
+         * @param {string} txHash The hash of the faucet transaction
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getFaucetTransaction(networkId: string, addressId: string, txHash: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FaucetTransaction>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getFaucetTransaction(networkId, addressId, txHash, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['ExternalAddressesApi.getFaucetTransaction']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * List all of the balances of an external address
          * @summary Get the balances of an external address
          * @param {string} networkId The ID of the blockchain network
@@ -5359,11 +5854,12 @@ export const ExternalAddressesApiFp = function(configuration?: Configuration) {
          * @param {string} networkId The ID of the wallet the address belongs to.
          * @param {string} addressId The onchain address of the address that is being fetched.
          * @param {string} [assetId] The ID of the asset to transfer from the faucet.
+         * @param {boolean} [skipWait] Whether to skip waiting for the transaction to be mined. This will become the default behavior in the future.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async requestExternalFaucetFunds(networkId: string, addressId: string, assetId?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FaucetTransaction>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.requestExternalFaucetFunds(networkId, addressId, assetId, options);
+        async requestExternalFaucetFunds(networkId: string, addressId: string, assetId?: string, skipWait?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FaucetTransaction>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.requestExternalFaucetFunds(networkId, addressId, assetId, skipWait, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['ExternalAddressesApi.requestExternalFaucetFunds']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -5391,6 +5887,18 @@ export const ExternalAddressesApiFactory = function (configuration?: Configurati
             return localVarFp.getExternalAddressBalance(networkId, addressId, assetId, options).then((request) => request(axios, basePath));
         },
         /**
+         * Get the status of a faucet transaction
+         * @summary Get the status of a faucet transaction
+         * @param {string} networkId The ID of the blockchain network
+         * @param {string} addressId The ID of the address to fetch the faucet transaction for
+         * @param {string} txHash The hash of the faucet transaction
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getFaucetTransaction(networkId: string, addressId: string, txHash: string, options?: RawAxiosRequestConfig): AxiosPromise<FaucetTransaction> {
+            return localVarFp.getFaucetTransaction(networkId, addressId, txHash, options).then((request) => request(axios, basePath));
+        },
+        /**
          * List all of the balances of an external address
          * @summary Get the balances of an external address
          * @param {string} networkId The ID of the blockchain network
@@ -5408,11 +5916,12 @@ export const ExternalAddressesApiFactory = function (configuration?: Configurati
          * @param {string} networkId The ID of the wallet the address belongs to.
          * @param {string} addressId The onchain address of the address that is being fetched.
          * @param {string} [assetId] The ID of the asset to transfer from the faucet.
+         * @param {boolean} [skipWait] Whether to skip waiting for the transaction to be mined. This will become the default behavior in the future.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        requestExternalFaucetFunds(networkId: string, addressId: string, assetId?: string, options?: RawAxiosRequestConfig): AxiosPromise<FaucetTransaction> {
-            return localVarFp.requestExternalFaucetFunds(networkId, addressId, assetId, options).then((request) => request(axios, basePath));
+        requestExternalFaucetFunds(networkId: string, addressId: string, assetId?: string, skipWait?: boolean, options?: RawAxiosRequestConfig): AxiosPromise<FaucetTransaction> {
+            return localVarFp.requestExternalFaucetFunds(networkId, addressId, assetId, skipWait, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -5436,6 +5945,18 @@ export interface ExternalAddressesApiInterface {
     getExternalAddressBalance(networkId: string, addressId: string, assetId: string, options?: RawAxiosRequestConfig): AxiosPromise<Balance>;
 
     /**
+     * Get the status of a faucet transaction
+     * @summary Get the status of a faucet transaction
+     * @param {string} networkId The ID of the blockchain network
+     * @param {string} addressId The ID of the address to fetch the faucet transaction for
+     * @param {string} txHash The hash of the faucet transaction
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ExternalAddressesApiInterface
+     */
+    getFaucetTransaction(networkId: string, addressId: string, txHash: string, options?: RawAxiosRequestConfig): AxiosPromise<FaucetTransaction>;
+
+    /**
      * List all of the balances of an external address
      * @summary Get the balances of an external address
      * @param {string} networkId The ID of the blockchain network
@@ -5453,11 +5974,12 @@ export interface ExternalAddressesApiInterface {
      * @param {string} networkId The ID of the wallet the address belongs to.
      * @param {string} addressId The onchain address of the address that is being fetched.
      * @param {string} [assetId] The ID of the asset to transfer from the faucet.
+     * @param {boolean} [skipWait] Whether to skip waiting for the transaction to be mined. This will become the default behavior in the future.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ExternalAddressesApiInterface
      */
-    requestExternalFaucetFunds(networkId: string, addressId: string, assetId?: string, options?: RawAxiosRequestConfig): AxiosPromise<FaucetTransaction>;
+    requestExternalFaucetFunds(networkId: string, addressId: string, assetId?: string, skipWait?: boolean, options?: RawAxiosRequestConfig): AxiosPromise<FaucetTransaction>;
 
 }
 
@@ -5483,6 +6005,20 @@ export class ExternalAddressesApi extends BaseAPI implements ExternalAddressesAp
     }
 
     /**
+     * Get the status of a faucet transaction
+     * @summary Get the status of a faucet transaction
+     * @param {string} networkId The ID of the blockchain network
+     * @param {string} addressId The ID of the address to fetch the faucet transaction for
+     * @param {string} txHash The hash of the faucet transaction
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ExternalAddressesApi
+     */
+    public getFaucetTransaction(networkId: string, addressId: string, txHash: string, options?: RawAxiosRequestConfig) {
+        return ExternalAddressesApiFp(this.configuration).getFaucetTransaction(networkId, addressId, txHash, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
      * List all of the balances of an external address
      * @summary Get the balances of an external address
      * @param {string} networkId The ID of the blockchain network
@@ -5502,12 +6038,454 @@ export class ExternalAddressesApi extends BaseAPI implements ExternalAddressesAp
      * @param {string} networkId The ID of the wallet the address belongs to.
      * @param {string} addressId The onchain address of the address that is being fetched.
      * @param {string} [assetId] The ID of the asset to transfer from the faucet.
+     * @param {boolean} [skipWait] Whether to skip waiting for the transaction to be mined. This will become the default behavior in the future.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ExternalAddressesApi
      */
-    public requestExternalFaucetFunds(networkId: string, addressId: string, assetId?: string, options?: RawAxiosRequestConfig) {
-        return ExternalAddressesApiFp(this.configuration).requestExternalFaucetFunds(networkId, addressId, assetId, options).then((request) => request(this.axios, this.basePath));
+    public requestExternalFaucetFunds(networkId: string, addressId: string, assetId?: string, skipWait?: boolean, options?: RawAxiosRequestConfig) {
+        return ExternalAddressesApiFp(this.configuration).requestExternalFaucetFunds(networkId, addressId, assetId, skipWait, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
+ * FundApi - axios parameter creator
+ * @export
+ */
+export const FundApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * Create a new fund operation with an address.
+         * @summary Create a new fund operation.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The onchain address to be funded.
+         * @param {CreateFundOperationRequest} createFundOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createFundOperation: async (walletId: string, addressId: string, createFundOperationRequest: CreateFundOperationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('createFundOperation', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('createFundOperation', 'addressId', addressId)
+            // verify required parameter 'createFundOperationRequest' is not null or undefined
+            assertParamExists('createFundOperation', 'createFundOperationRequest', createFundOperationRequest)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/fund_operations`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(createFundOperationRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Create a new fund operation with an address.
+         * @summary Create a Fund Operation quote.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The onchain address to be funded.
+         * @param {CreateFundQuoteRequest} createFundQuoteRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createFundQuote: async (walletId: string, addressId: string, createFundQuoteRequest: CreateFundQuoteRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('createFundQuote', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('createFundQuote', 'addressId', addressId)
+            // verify required parameter 'createFundQuoteRequest' is not null or undefined
+            assertParamExists('createFundQuote', 'createFundQuoteRequest', createFundQuoteRequest)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/fund_operations/quote`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(createFundQuoteRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Get fund operation.
+         * @summary Get fund operation.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The onchain address of the address that created the fund operation.
+         * @param {string} fundOperationId The ID of the fund operation to fetch.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getFundOperation: async (walletId: string, addressId: string, fundOperationId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('getFundOperation', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('getFundOperation', 'addressId', addressId)
+            // verify required parameter 'fundOperationId' is not null or undefined
+            assertParamExists('getFundOperation', 'fundOperationId', fundOperationId)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/fund_operations/{fund_operation_id}`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)))
+                .replace(`{${"fund_operation_id"}}`, encodeURIComponent(String(fundOperationId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * List fund operations for an address.
+         * @summary List fund operations for an address.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The onchain address of the address to list fund operations for.
+         * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+         * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listFundOperations: async (walletId: string, addressId: string, limit?: number, page?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'walletId' is not null or undefined
+            assertParamExists('listFundOperations', 'walletId', walletId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('listFundOperations', 'addressId', addressId)
+            const localVarPath = `/v1/wallets/{wallet_id}/addresses/{address_id}/fund_operations`
+                .replace(`{${"wallet_id"}}`, encodeURIComponent(String(walletId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (limit !== undefined) {
+                localVarQueryParameter['limit'] = limit;
+            }
+
+            if (page !== undefined) {
+                localVarQueryParameter['page'] = page;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * FundApi - functional programming interface
+ * @export
+ */
+export const FundApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = FundApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * Create a new fund operation with an address.
+         * @summary Create a new fund operation.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The onchain address to be funded.
+         * @param {CreateFundOperationRequest} createFundOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async createFundOperation(walletId: string, addressId: string, createFundOperationRequest: CreateFundOperationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FundOperation>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createFundOperation(walletId, addressId, createFundOperationRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['FundApi.createFundOperation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Create a new fund operation with an address.
+         * @summary Create a Fund Operation quote.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The onchain address to be funded.
+         * @param {CreateFundQuoteRequest} createFundQuoteRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async createFundQuote(walletId: string, addressId: string, createFundQuoteRequest: CreateFundQuoteRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FundQuote>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createFundQuote(walletId, addressId, createFundQuoteRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['FundApi.createFundQuote']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Get fund operation.
+         * @summary Get fund operation.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The onchain address of the address that created the fund operation.
+         * @param {string} fundOperationId The ID of the fund operation to fetch.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getFundOperation(walletId: string, addressId: string, fundOperationId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FundOperation>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getFundOperation(walletId, addressId, fundOperationId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['FundApi.getFundOperation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * List fund operations for an address.
+         * @summary List fund operations for an address.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The onchain address of the address to list fund operations for.
+         * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+         * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async listFundOperations(walletId: string, addressId: string, limit?: number, page?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FundOperationList>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listFundOperations(walletId, addressId, limit, page, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['FundApi.listFundOperations']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * FundApi - factory interface
+ * @export
+ */
+export const FundApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = FundApiFp(configuration)
+    return {
+        /**
+         * Create a new fund operation with an address.
+         * @summary Create a new fund operation.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The onchain address to be funded.
+         * @param {CreateFundOperationRequest} createFundOperationRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createFundOperation(walletId: string, addressId: string, createFundOperationRequest: CreateFundOperationRequest, options?: RawAxiosRequestConfig): AxiosPromise<FundOperation> {
+            return localVarFp.createFundOperation(walletId, addressId, createFundOperationRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Create a new fund operation with an address.
+         * @summary Create a Fund Operation quote.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The onchain address to be funded.
+         * @param {CreateFundQuoteRequest} createFundQuoteRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createFundQuote(walletId: string, addressId: string, createFundQuoteRequest: CreateFundQuoteRequest, options?: RawAxiosRequestConfig): AxiosPromise<FundQuote> {
+            return localVarFp.createFundQuote(walletId, addressId, createFundQuoteRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Get fund operation.
+         * @summary Get fund operation.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The onchain address of the address that created the fund operation.
+         * @param {string} fundOperationId The ID of the fund operation to fetch.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getFundOperation(walletId: string, addressId: string, fundOperationId: string, options?: RawAxiosRequestConfig): AxiosPromise<FundOperation> {
+            return localVarFp.getFundOperation(walletId, addressId, fundOperationId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * List fund operations for an address.
+         * @summary List fund operations for an address.
+         * @param {string} walletId The ID of the wallet the address belongs to.
+         * @param {string} addressId The onchain address of the address to list fund operations for.
+         * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+         * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listFundOperations(walletId: string, addressId: string, limit?: number, page?: string, options?: RawAxiosRequestConfig): AxiosPromise<FundOperationList> {
+            return localVarFp.listFundOperations(walletId, addressId, limit, page, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * FundApi - interface
+ * @export
+ * @interface FundApi
+ */
+export interface FundApiInterface {
+    /**
+     * Create a new fund operation with an address.
+     * @summary Create a new fund operation.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The onchain address to be funded.
+     * @param {CreateFundOperationRequest} createFundOperationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof FundApiInterface
+     */
+    createFundOperation(walletId: string, addressId: string, createFundOperationRequest: CreateFundOperationRequest, options?: RawAxiosRequestConfig): AxiosPromise<FundOperation>;
+
+    /**
+     * Create a new fund operation with an address.
+     * @summary Create a Fund Operation quote.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The onchain address to be funded.
+     * @param {CreateFundQuoteRequest} createFundQuoteRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof FundApiInterface
+     */
+    createFundQuote(walletId: string, addressId: string, createFundQuoteRequest: CreateFundQuoteRequest, options?: RawAxiosRequestConfig): AxiosPromise<FundQuote>;
+
+    /**
+     * Get fund operation.
+     * @summary Get fund operation.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The onchain address of the address that created the fund operation.
+     * @param {string} fundOperationId The ID of the fund operation to fetch.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof FundApiInterface
+     */
+    getFundOperation(walletId: string, addressId: string, fundOperationId: string, options?: RawAxiosRequestConfig): AxiosPromise<FundOperation>;
+
+    /**
+     * List fund operations for an address.
+     * @summary List fund operations for an address.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The onchain address of the address to list fund operations for.
+     * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+     * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof FundApiInterface
+     */
+    listFundOperations(walletId: string, addressId: string, limit?: number, page?: string, options?: RawAxiosRequestConfig): AxiosPromise<FundOperationList>;
+
+}
+
+/**
+ * FundApi - object-oriented interface
+ * @export
+ * @class FundApi
+ * @extends {BaseAPI}
+ */
+export class FundApi extends BaseAPI implements FundApiInterface {
+    /**
+     * Create a new fund operation with an address.
+     * @summary Create a new fund operation.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The onchain address to be funded.
+     * @param {CreateFundOperationRequest} createFundOperationRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof FundApi
+     */
+    public createFundOperation(walletId: string, addressId: string, createFundOperationRequest: CreateFundOperationRequest, options?: RawAxiosRequestConfig) {
+        return FundApiFp(this.configuration).createFundOperation(walletId, addressId, createFundOperationRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Create a new fund operation with an address.
+     * @summary Create a Fund Operation quote.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The onchain address to be funded.
+     * @param {CreateFundQuoteRequest} createFundQuoteRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof FundApi
+     */
+    public createFundQuote(walletId: string, addressId: string, createFundQuoteRequest: CreateFundQuoteRequest, options?: RawAxiosRequestConfig) {
+        return FundApiFp(this.configuration).createFundQuote(walletId, addressId, createFundQuoteRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Get fund operation.
+     * @summary Get fund operation.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The onchain address of the address that created the fund operation.
+     * @param {string} fundOperationId The ID of the fund operation to fetch.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof FundApi
+     */
+    public getFundOperation(walletId: string, addressId: string, fundOperationId: string, options?: RawAxiosRequestConfig) {
+        return FundApiFp(this.configuration).getFundOperation(walletId, addressId, fundOperationId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * List fund operations for an address.
+     * @summary List fund operations for an address.
+     * @param {string} walletId The ID of the wallet the address belongs to.
+     * @param {string} addressId The onchain address of the address to list fund operations for.
+     * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+     * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof FundApi
+     */
+    public listFundOperations(walletId: string, addressId: string, limit?: number, page?: string, options?: RawAxiosRequestConfig) {
+        return FundApiFp(this.configuration).listFundOperations(walletId, addressId, limit, page, options).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -5637,6 +6615,175 @@ export class NetworksApi extends BaseAPI implements NetworksApiInterface {
     }
 }
 
+
+
+/**
+ * OnchainIdentityApi - axios parameter creator
+ * @export
+ */
+export const OnchainIdentityApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * Obtains onchain identity for an address on a specific network
+         * @summary Obtains onchain identity for an address on a specific network
+         * @param {string} networkId The ID of the blockchain network
+         * @param {string} addressId The ID of the address to fetch the identity for
+         * @param {Array<ResolveIdentityByAddressRolesEnum>} [roles] A filter by role of the names related to this address (managed or owned)
+         * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+         * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        resolveIdentityByAddress: async (networkId: string, addressId: string, roles?: Array<ResolveIdentityByAddressRolesEnum>, limit?: number, page?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'networkId' is not null or undefined
+            assertParamExists('resolveIdentityByAddress', 'networkId', networkId)
+            // verify required parameter 'addressId' is not null or undefined
+            assertParamExists('resolveIdentityByAddress', 'addressId', addressId)
+            const localVarPath = `/v1/networks/{network_id}/addresses/{address_id}/identity`
+                .replace(`{${"network_id"}}`, encodeURIComponent(String(networkId)))
+                .replace(`{${"address_id"}}`, encodeURIComponent(String(addressId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (roles) {
+                localVarQueryParameter['roles'] = roles.join(COLLECTION_FORMATS.csv);
+            }
+
+            if (limit !== undefined) {
+                localVarQueryParameter['limit'] = limit;
+            }
+
+            if (page !== undefined) {
+                localVarQueryParameter['page'] = page;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * OnchainIdentityApi - functional programming interface
+ * @export
+ */
+export const OnchainIdentityApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = OnchainIdentityApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * Obtains onchain identity for an address on a specific network
+         * @summary Obtains onchain identity for an address on a specific network
+         * @param {string} networkId The ID of the blockchain network
+         * @param {string} addressId The ID of the address to fetch the identity for
+         * @param {Array<ResolveIdentityByAddressRolesEnum>} [roles] A filter by role of the names related to this address (managed or owned)
+         * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+         * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async resolveIdentityByAddress(networkId: string, addressId: string, roles?: Array<ResolveIdentityByAddressRolesEnum>, limit?: number, page?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<OnchainNameList>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.resolveIdentityByAddress(networkId, addressId, roles, limit, page, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['OnchainIdentityApi.resolveIdentityByAddress']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * OnchainIdentityApi - factory interface
+ * @export
+ */
+export const OnchainIdentityApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = OnchainIdentityApiFp(configuration)
+    return {
+        /**
+         * Obtains onchain identity for an address on a specific network
+         * @summary Obtains onchain identity for an address on a specific network
+         * @param {string} networkId The ID of the blockchain network
+         * @param {string} addressId The ID of the address to fetch the identity for
+         * @param {Array<ResolveIdentityByAddressRolesEnum>} [roles] A filter by role of the names related to this address (managed or owned)
+         * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+         * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        resolveIdentityByAddress(networkId: string, addressId: string, roles?: Array<ResolveIdentityByAddressRolesEnum>, limit?: number, page?: string, options?: RawAxiosRequestConfig): AxiosPromise<OnchainNameList> {
+            return localVarFp.resolveIdentityByAddress(networkId, addressId, roles, limit, page, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * OnchainIdentityApi - interface
+ * @export
+ * @interface OnchainIdentityApi
+ */
+export interface OnchainIdentityApiInterface {
+    /**
+     * Obtains onchain identity for an address on a specific network
+     * @summary Obtains onchain identity for an address on a specific network
+     * @param {string} networkId The ID of the blockchain network
+     * @param {string} addressId The ID of the address to fetch the identity for
+     * @param {Array<ResolveIdentityByAddressRolesEnum>} [roles] A filter by role of the names related to this address (managed or owned)
+     * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+     * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OnchainIdentityApiInterface
+     */
+    resolveIdentityByAddress(networkId: string, addressId: string, roles?: Array<ResolveIdentityByAddressRolesEnum>, limit?: number, page?: string, options?: RawAxiosRequestConfig): AxiosPromise<OnchainNameList>;
+
+}
+
+/**
+ * OnchainIdentityApi - object-oriented interface
+ * @export
+ * @class OnchainIdentityApi
+ * @extends {BaseAPI}
+ */
+export class OnchainIdentityApi extends BaseAPI implements OnchainIdentityApiInterface {
+    /**
+     * Obtains onchain identity for an address on a specific network
+     * @summary Obtains onchain identity for an address on a specific network
+     * @param {string} networkId The ID of the blockchain network
+     * @param {string} addressId The ID of the address to fetch the identity for
+     * @param {Array<ResolveIdentityByAddressRolesEnum>} [roles] A filter by role of the names related to this address (managed or owned)
+     * @param {number} [limit] A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+     * @param {string} [page] A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OnchainIdentityApi
+     */
+    public resolveIdentityByAddress(networkId: string, addressId: string, roles?: Array<ResolveIdentityByAddressRolesEnum>, limit?: number, page?: string, options?: RawAxiosRequestConfig) {
+        return OnchainIdentityApiFp(this.configuration).resolveIdentityByAddress(networkId, addressId, roles, limit, page, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+/**
+ * @export
+ */
+export const ResolveIdentityByAddressRolesEnum = {
+    Managed: 'managed',
+    Owned: 'owned'
+} as const;
+export type ResolveIdentityByAddressRolesEnum = typeof ResolveIdentityByAddressRolesEnum[keyof typeof ResolveIdentityByAddressRolesEnum];
 
 
 /**

--- a/src/coinbase/address.ts
+++ b/src/coinbase/address.ts
@@ -291,6 +291,7 @@ export class Address {
       this.getNetworkId(),
       this.getId(),
       assetId,
+      true, // Skip waiting for confirmation server-side.
     );
     return new FaucetTransaction(response.data);
   }

--- a/src/coinbase/faucet_transaction.ts
+++ b/src/coinbase/faucet_transaction.ts
@@ -1,10 +1,13 @@
 import { FaucetTransaction as FaucetTransactionModel } from "../client";
+import { TransactionStatus } from "./types";
+import { Transaction } from "./transaction";
 
 /**
  * Represents a transaction from a faucet.
  */
 export class FaucetTransaction {
   private model: FaucetTransactionModel;
+  private _transaction: Transaction;
 
   /**
    * Creates a new FaucetTransaction instance.
@@ -15,10 +18,21 @@ export class FaucetTransaction {
    * @throws {Error} If the model does not exist.
    */
   constructor(model: FaucetTransactionModel) {
-    if (!model?.transaction_hash) {
+    if (!model?.transaction) {
       throw new Error("FaucetTransaction model cannot be empty");
     }
+
     this.model = model;
+    this._transaction = new Transaction(this.model.transaction!);
+  }
+
+  /**
+   * Returns the Transaction of the FaucetTransaction.
+   *
+   * @returns The Faucet Transaction
+   */
+  public get transaction(): Transaction {
+    return this._transaction;
   }
 
   /**
@@ -27,7 +41,7 @@ export class FaucetTransaction {
    * @returns {string} The transaction hash.
    */
   public getTransactionHash(): string {
-    return this.model.transaction_hash;
+    return this.transaction.getTransactionHash()!;
   }
 
   /**
@@ -36,7 +50,34 @@ export class FaucetTransaction {
    * @returns {string} The link to the transaction on the blockchain explorer
    */
   public getTransactionLink(): string {
-    return this.model.transaction_link;
+    return this.transaction.getTransactionLink()!;
+  }
+
+  /**
+   * Returns the Status of the FaucetTransaction.
+   *
+   * @returns The Status of the FaucetTransaction.
+   */
+  public getStatus(): TransactionStatus {
+    return this.transaction.getStatus();
+  }
+
+  /**
+   * Returns the network ID of the FaucetTransaction.
+   *
+   * @returns {string} The network ID.
+   */
+  public getNetworkId(): string {
+    return this.transaction.getNetworkId();
+  }
+
+  /**
+   * Returns the address that is being funded by the faucet.
+   *
+   * @returns {string} The address ID.
+   */
+  public getAddressId(): string {
+    return this.transaction.toAddressId()!;
   }
 
   /**

--- a/src/coinbase/faucet_transaction.ts
+++ b/src/coinbase/faucet_transaction.ts
@@ -1,6 +1,9 @@
 import { FaucetTransaction as FaucetTransactionModel } from "../client";
 import { TransactionStatus } from "./types";
+import { Coinbase } from "./coinbase";
 import { Transaction } from "./transaction";
+import { delay } from "./utils";
+import { TimeoutError } from "./errors";
 
 /**
  * Represents a transaction from a faucet.
@@ -78,6 +81,62 @@ export class FaucetTransaction {
    */
   public getAddressId(): string {
     return this.transaction.toAddressId()!;
+  }
+
+  /**
+   * Waits for the FaucetTransaction to be confirmed on the Network or fail on chain.
+   * Waits until the FaucetTransaction is completed or failed on-chain by polling at the given interval.
+   * Raises an error if the FaucetTransaction takes longer than the given timeout.
+   *
+   * @param options - The options to configure the wait function.
+   * @param options.intervalSeconds - The interval to check the status of the FaucetTransaction.
+   * @param options.timeoutSeconds - The maximum time to wait for the FaucetTransaction to be confirmed.
+   *
+   * @returns The FaucetTransaction object in a terminal state.
+   * @throws {Error} if the FaucetTransaction times out.
+   */
+  public async wait({
+    intervalSeconds = 0.2,
+    timeoutSeconds = 10,
+  } = {}): Promise<FaucetTransaction> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutSeconds * 1000) {
+      await this.reload();
+
+      // If the FaucetTransaction is in a terminal state, return the FaucetTransaction.
+      if (this.transaction.isTerminalState()) {
+        return this;
+      }
+
+      await delay(intervalSeconds);
+    }
+
+    throw new TimeoutError("FaucetTransaction timed out");
+  }
+
+  /**
+   * Reloads the FaucetTransaction model with the latest data from the server.
+   *
+   * @returns {FaucetTransaction} The reloaded FaucetTransaction object.
+   * @throws {APIError} if the API request to get a FaucetTransaction fails.
+   */
+  public async reload(): Promise<FaucetTransaction> {
+    const result = await Coinbase.apiClients.externalAddress!.getFaucetTransaction(
+      this.transaction.getNetworkId(),
+      this.getAddressId(),
+      this.getTransactionHash(),
+    );
+
+    this.model = result?.data;
+
+    if (!this.model?.transaction) {
+      throw new Error("FaucetTransaction model cannot be empty");
+    }
+
+    this._transaction = new Transaction(this.model.transaction!);
+
+    return this;
   }
 
   /**

--- a/src/coinbase/transaction.ts
+++ b/src/coinbase/transaction.ts
@@ -55,19 +55,32 @@ export class Transaction {
    *
    * @returns The Status
    */
-  getStatus(): TransactionStatus | undefined {
+  getStatus(): TransactionStatus {
     switch (this.model.status) {
       case TransactionStatus.PENDING:
         return TransactionStatus.PENDING;
       case TransactionStatus.BROADCAST:
         return TransactionStatus.BROADCAST;
+      case TransactionStatus.SIGNED:
+        return TransactionStatus.SIGNED;
       case TransactionStatus.COMPLETE:
         return TransactionStatus.COMPLETE;
       case TransactionStatus.FAILED:
         return TransactionStatus.FAILED;
       default:
-        return undefined;
+        return TransactionStatus.UNSPECIFIED;
     }
+  }
+
+  /**
+   * Returns whether the Transaction is in a terminal State.
+   *
+   * @returns Whether the Transaction is in a terminal State
+   */
+  isTerminalState(): boolean {
+    const status = this.getStatus();
+
+    return [TransactionStatus.COMPLETE, TransactionStatus.FAILED].includes(status);
   }
 
   /**
@@ -113,18 +126,6 @@ export class Transaction {
    */
   content(): EthereumTransaction | undefined {
     return this.model.content;
-  }
-  /**
-   * Returns whether the Transaction is in a terminal State.
-   *
-   * @returns Whether the Transaction is in a terminal State
-   */
-  isTerminalState(): boolean {
-    const status = this.getStatus();
-
-    if (!status) return false;
-
-    return [TransactionStatus.COMPLETE, TransactionStatus.FAILED].includes(status);
   }
 
   /**

--- a/src/coinbase/transaction.ts
+++ b/src/coinbase/transaction.ts
@@ -137,6 +137,15 @@ export class Transaction {
   }
 
   /**
+   * Returns the Network ID of the Transaction.
+   *
+   * @returns The Network ID.
+   */
+  public getNetworkId(): string {
+    return this.model.network_id;
+  }
+
+  /**
    * Returns the underlying raw transaction.
    *
    * @throws {InvalidUnsignedPayload} If the Unsigned Payload is invalid.

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -418,6 +418,23 @@ export type ExternalAddressAPIClient = {
     skipWait?: boolean,
     options?: RawAxiosRequestConfig,
   ): AxiosPromise<FaucetTransaction>;
+
+  /**
+   * Get the faucet transaction for an external address.
+   *
+   * @param networkId - The ID of the blockchain network
+   * @param addressId - The onchain address of the address that is being fetched.
+   * @param transactionHash - The transaction hash of the faucet transaction.
+   * @param options - Override http request option.
+   * @throws {APIError} If the request fails.
+   * @returns The faucet transaction.
+   */
+  getFaucetTransaction(
+    networkId: string,
+    addressId: string,
+    transactionHash: string,
+    options?: RawAxiosRequestConfig,
+  ): AxiosPromise<FaucetTransaction>;
 };
 
 export type WalletStakeAPIClient = {

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -237,16 +237,6 @@ export type WalletAPIClient = {
  */
 export type AddressAPIClient = {
   /**
-   * Requests faucet funds for the address.
-   *
-   * @param walletId - The wallet ID.
-   * @param addressId - The address ID.
-   * @returns The transaction hash.
-   * @throws {APIError} If the request fails.
-   */
-  requestFaucetFunds(walletId: string, addressId: string): AxiosPromise<FaucetTransaction>;
-
-  /**
    * Get address by onchain address.
    *
    * @param walletId - The ID of the wallet the address belongs to.
@@ -416,6 +406,8 @@ export type ExternalAddressAPIClient = {
    *
    * @param networkId - The ID of the blockchain network
    * @param addressId - The onchain address of the address that is being fetched.
+   * @param assetId - The Optional ID of the asset to request funds for. Defaults to native asset.
+   * @param skipWait - The Optional flag to skip waiting for the transaction to be mined. Defaults to false.
    * @param options - Override http request option.
    * @throws {APIError} If the request fails.
    */
@@ -423,6 +415,7 @@ export type ExternalAddressAPIClient = {
     networkId: string,
     addressId: string,
     assetId?: string,
+    skipWait?: boolean,
     options?: RawAxiosRequestConfig,
   ): AxiosPromise<FaucetTransaction>;
 };

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -724,9 +724,11 @@ export enum TransferStatus {
  */
 export enum TransactionStatus {
   PENDING = "pending",
+  SIGNED = "signed",
   BROADCAST = "broadcast",
   COMPLETE = "complete",
   FAILED = "failed",
+  UNSPECIFIED = "unspecified",
 }
 
 /**

--- a/src/tests/coinbase_test.ts
+++ b/src/tests/coinbase_test.ts
@@ -109,9 +109,6 @@ describe("Coinbase tests", () => {
 
       Coinbase.apiClients.wallet!.createWallet = mockReturnValue(walletModel);
       Coinbase.apiClients.wallet!.getWallet = mockReturnValue(walletModel);
-      Coinbase.apiClients.address!.requestFaucetFunds = mockReturnValue({
-        transaction_hash: transactionHash,
-      });
       Coinbase.apiClients.address!.createAddress = mockReturnValue(
         VALID_WALLET_MODEL.default_address,
       );

--- a/src/tests/external_address_test.ts
+++ b/src/tests/external_address_test.ts
@@ -603,6 +603,7 @@ describe("ExternalAddress", () => {
         address.getNetworkId(),
         address.getId(),
         undefined,
+        true, // Skip wait should be true.
       );
     });
 

--- a/src/tests/external_address_test.ts
+++ b/src/tests/external_address_test.ts
@@ -8,6 +8,7 @@ import {
   newAddressModel,
   stakeApiMock,
   validatorApiMock,
+  VALID_FAUCET_TRANSACTION_MODEL,
 } from "./utils";
 import {
   AddressBalanceList,
@@ -193,7 +194,7 @@ describe("ExternalAddress", () => {
     jest.clearAllMocks();
   });
 
-  describe(".buildStakeOperation", () => {
+  describe("#buildStakeOperation", () => {
     it("should successfully build a stake operation", async () => {
       Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
       Coinbase.apiClients.stake!.buildStakingOperation = mockReturnValue(STAKING_OPERATION_MODEL);
@@ -263,7 +264,7 @@ describe("ExternalAddress", () => {
     });
   });
 
-  describe(".buildUnstakeOperation", () => {
+  describe("#buildUnstakeOperation", () => {
     it("should successfully build a unstake operation", async () => {
       Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
       Coinbase.apiClients.stake!.buildStakingOperation = mockReturnValue(STAKING_OPERATION_MODEL);
@@ -328,7 +329,7 @@ describe("ExternalAddress", () => {
     });
   });
 
-  describe(".buildClaimStakeOperation", () => {
+  describe("#buildClaimStakeOperation", () => {
     it("should successfully build a claim stake operation", async () => {
       Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
       Coinbase.apiClients.stake!.buildStakingOperation = mockReturnValue(STAKING_OPERATION_MODEL);
@@ -403,7 +404,7 @@ describe("ExternalAddress", () => {
     });
   });
 
-  describe(".stakingRewards", () => {
+  describe("#stakingRewards", () => {
     it("should return staking rewards successfully", async () => {
       Coinbase.apiClients.stake!.fetchStakingRewards = mockReturnValue(STAKING_REWARD_RESPONSE);
       Coinbase.apiClients.asset!.getAsset = getAssetMock();
@@ -426,7 +427,7 @@ describe("ExternalAddress", () => {
     });
   });
 
-  describe(".historicalStakingBalances", () => {
+  describe("#historicalStakingBalances", () => {
     it("should return staking balances successfully", async () => {
       Coinbase.apiClients.stake!.fetchHistoricalStakingBalances = mockReturnValue(
         HISTORICAL_STAKING_BALANCES_RESPONSE,
@@ -452,7 +453,7 @@ describe("ExternalAddress", () => {
     });
   });
 
-  describe(".listBalances", () => {
+  describe("#listBalances", () => {
     beforeEach(() => {
       const mockBalanceResponse: AddressBalanceList = {
         data: [
@@ -514,7 +515,7 @@ describe("ExternalAddress", () => {
     });
   });
 
-  describe(".getBalance", () => {
+  describe("#getBalance", () => {
     beforeEach(() => {
       const mockWalletBalance: Balance = {
         amount: "5000000000000000000",
@@ -582,16 +583,27 @@ describe("ExternalAddress", () => {
     });
   });
 
-  describe(".faucet", () => {
+  describe("#faucet", () => {
     beforeEach(() => {
-      Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds = mockReturnValue({
-        transaction_hash: generateRandomHash(8),
-      });
+      Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds = mockReturnValue(VALID_FAUCET_TRANSACTION_MODEL);
     });
 
     it("should successfully request funds from the faucet", async () => {
-      const transaction = await address.faucet();
-      expect(transaction.getTransactionHash()).toEqual(expect.any(String));
+      const faucetTx = await address.faucet();
+
+      const {
+        transaction_hash: txHash,
+        transaction_link: txLink,
+      } = VALID_FAUCET_TRANSACTION_MODEL.transaction;
+
+      expect(faucetTx.getTransactionHash()).toEqual(txHash);
+      expect(faucetTx.getTransactionLink()).toEqual(txLink);
+
+      expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledWith(
+        address.getNetworkId(),
+        address.getId(),
+        undefined,
+      );
     });
 
     it("should throw an error if the faucet request fails", async () => {
@@ -600,7 +612,7 @@ describe("ExternalAddress", () => {
     });
   });
 
-  describe(".stakeableBalance", () => {
+  describe("#stakeableBalance", () => {
     it("should return the stakeable balance successfully with default params", async () => {
       Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
       const stakeableBalance = await address.stakeableBalance(Coinbase.assets.Eth);
@@ -634,7 +646,7 @@ describe("ExternalAddress", () => {
     });
   });
 
-  describe(".unstakeableBalance", () => {
+  describe("#unstakeableBalance", () => {
     it("should return the unstakeable balance successfully with default params", async () => {
       Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
       const unstakeableBalance = await address.unstakeableBalance(Coinbase.assets.Eth);
@@ -668,7 +680,7 @@ describe("ExternalAddress", () => {
     });
   });
 
-  describe(".claimableBalance", () => {
+  describe("#claimableBalance", () => {
     it("should return the claimable balance successfully with default params", async () => {
       Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
       const claimableBalance = await address.claimableBalance(Coinbase.assets.Eth);

--- a/src/tests/faucet_transaction_test.ts
+++ b/src/tests/faucet_transaction_test.ts
@@ -1,6 +1,11 @@
 import { FaucetTransaction } from "../coinbase/faucet_transaction";
+import { TransactionStatusEnum } from "../client/api";
+import { Coinbase } from "../coinbase/coinbase";
 import {
   VALID_FAUCET_TRANSACTION_MODEL,
+  mockReturnValue,
+  mockReturnRejectedValue,
+  externalAddressApiMock,
 } from "./utils";
 
 describe("FaucetTransaction tests", () => {
@@ -14,6 +19,8 @@ describe("FaucetTransaction tests", () => {
   } = VALID_FAUCET_TRANSACTION_MODEL.transaction!;
 
   beforeEach(() => {
+    Coinbase.apiClients.externalAddress = externalAddressApiMock;
+
     faucetTransaction = new FaucetTransaction(VALID_FAUCET_TRANSACTION_MODEL);
   });
 
@@ -49,6 +56,133 @@ describe("FaucetTransaction tests", () => {
   describe("#getAddressId", () => {
     it("returns the transaction to address ID", () => {
       expect(faucetTransaction.getAddressId()).toBe(toAddressId);
+    });
+  });
+
+  describe("#reload", () => {
+    let txStatus;
+    let reloadedFaucetTx: FaucetTransaction;
+
+    beforeEach(async () => {
+      Coinbase.apiClients.externalAddress!.getFaucetTransaction = mockReturnValue({
+        ...VALID_FAUCET_TRANSACTION_MODEL,
+        transaction: {
+          ...VALID_FAUCET_TRANSACTION_MODEL.transaction!,
+          status: txStatus,
+        },
+      });
+
+      reloadedFaucetTx = await faucetTransaction.reload();
+    });
+
+    [
+      TransactionStatusEnum.Pending,
+      TransactionStatusEnum.Complete,
+      TransactionStatusEnum.Failed,
+    ].forEach((status) => {
+      describe(`when the transaction is ${status}`, () => {
+        beforeAll(() => txStatus = status);
+
+        it("returns a FaucetTransaction", () => {
+          expect(reloadedFaucetTx).toBeInstanceOf(FaucetTransaction);
+        });
+
+        it("updates the FaucetTransaction", () => {
+          expect(faucetTransaction.getStatus()).toBe(status);
+        });
+
+        it("calls the API to get the FaucetTransaction", () => {
+          expect(Coinbase.apiClients.externalAddress!.getFaucetTransaction).toHaveBeenCalledWith(
+            networkId,
+            toAddressId,
+            txHash,
+          );
+          expect(Coinbase.apiClients.externalAddress!.getFaucetTransaction).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+  });
+
+  describe("#wait", () => {
+    describe("when the transaction eventually completes", () => {
+      beforeEach(() => {
+        Coinbase.apiClients.externalAddress!.getFaucetTransaction = jest.fn()
+          .mockResolvedValueOnce({ data: VALID_FAUCET_TRANSACTION_MODEL }) // Pending
+          .mockResolvedValueOnce({
+            data: {
+              ...VALID_FAUCET_TRANSACTION_MODEL,
+              transaction: {
+                ...VALID_FAUCET_TRANSACTION_MODEL.transaction!,
+                status: TransactionStatusEnum.Complete,
+              },
+            },
+          });
+      });
+
+      it("returns the completed FaucetTransaction", async () => {
+        const completedFaucetTx = await faucetTransaction.wait();
+
+        expect(completedFaucetTx).toBeInstanceOf(FaucetTransaction);
+        expect(completedFaucetTx.getStatus()).toBe(TransactionStatusEnum.Complete);
+      });
+
+      it("calls the API to get the FaucetTransaction", async () => {
+        await faucetTransaction.wait();
+
+        expect(Coinbase.apiClients.externalAddress!.getFaucetTransaction).toHaveBeenCalledWith(
+          networkId,
+          toAddressId,
+          txHash,
+        );
+        expect(Coinbase.apiClients.externalAddress!.getFaucetTransaction).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("when the transaction eventually fails", () => {
+      beforeEach(() => {
+        Coinbase.apiClients.externalAddress!.getFaucetTransaction = jest.fn()
+          .mockResolvedValueOnce({ data: VALID_FAUCET_TRANSACTION_MODEL }) // Pending
+          .mockResolvedValueOnce({
+            data: {
+              ...VALID_FAUCET_TRANSACTION_MODEL,
+              transaction: {
+                ...VALID_FAUCET_TRANSACTION_MODEL.transaction!,
+                status: TransactionStatusEnum.Failed,
+              },
+            },
+          });
+      });
+
+      it("returns the failed FaucetTransaction", async () => {
+        const failedFaucetTx = await faucetTransaction.wait();
+
+        expect(failedFaucetTx).toBeInstanceOf(FaucetTransaction);
+        expect(failedFaucetTx.getStatus()).toBe(TransactionStatusEnum.Failed);
+      });
+
+      it("calls the API to get the FaucetTransaction", async () => {
+        await faucetTransaction.wait();
+
+        expect(Coinbase.apiClients.externalAddress!.getFaucetTransaction).toHaveBeenCalledWith(
+          networkId,
+          toAddressId,
+          txHash,
+        );
+        expect(Coinbase.apiClients.externalAddress!.getFaucetTransaction).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("when the transaction times out", () => {
+      beforeEach(() => {
+        // Returns pending for every request.
+        Coinbase.apiClients.externalAddress!.getFaucetTransaction = jest.fn()
+          .mockResolvedValueOnce({ data: VALID_FAUCET_TRANSACTION_MODEL }) // Pending
+      });
+
+      it("throws a TimeoutError", async () => {
+        expect(faucetTransaction.wait({ timeoutSeconds: 0.001, intervalSeconds: 0.001 }))
+          .rejects.toThrow(new Error("FaucetTransaction timed out"));
+      });
     });
   });
 });

--- a/src/tests/faucet_transaction_test.ts
+++ b/src/tests/faucet_transaction_test.ts
@@ -1,21 +1,54 @@
 import { FaucetTransaction } from "../coinbase/faucet_transaction";
+import {
+  VALID_FAUCET_TRANSACTION_MODEL,
+} from "./utils";
 
 describe("FaucetTransaction tests", () => {
-  it("should create a new FaucetTransaction instance and return the transaction hash", () => {
-    const faucetTransaction = new FaucetTransaction({
-      transaction_hash: "abc",
-      transaction_link: "https://sepolia.basescan.org/tx/abc",
-    });
+  let faucetTransaction: FaucetTransaction;
+  let model;
+  const {
+    transaction_hash: txHash,
+    transaction_link: txLink,
+    network_id: networkId,
+    to_address_id: toAddressId,
+  } = VALID_FAUCET_TRANSACTION_MODEL.transaction!;
 
-    expect(faucetTransaction).toBeInstanceOf(FaucetTransaction);
-    expect(faucetTransaction.getTransactionHash()).toBe("abc");
-    expect(faucetTransaction.getTransactionLink()).toBe("https://sepolia.basescan.org/tx/abc");
-    expect(faucetTransaction.toString()).toBe(
-      "Coinbase::FaucetTransaction{transaction_hash: 'abc', transaction_link: 'https://sepolia.basescan.org/tx/abc'}",
-    );
+  beforeEach(() => {
+    faucetTransaction = new FaucetTransaction(VALID_FAUCET_TRANSACTION_MODEL);
   });
 
-  it("should throw an Error if model is not provided", () => {
-    expect(() => new FaucetTransaction(null!)).toThrow(`FaucetTransaction model cannot be empty`);
+  describe("constructor", () => {
+    it("initializes a FaucetTransaction", () => {
+      expect(faucetTransaction).toBeInstanceOf(FaucetTransaction);
+    });
+
+    it("throws an Error if model is not provided", () => {
+      expect(() => new FaucetTransaction(null!))
+        .toThrow(`FaucetTransaction model cannot be empty`);
+    });
+  });
+
+  describe("#getTransactionHash", () => {
+    it("returns the transaction hash", () => {
+      expect(faucetTransaction.getTransactionHash()).toBe(txHash);
+    });
+  });
+
+  describe("#getTransactionLink", () => {
+    it("returns the transaction link", () => {
+      expect(faucetTransaction.getTransactionLink()).toBe(txLink);
+    });
+  });
+
+  describe("#getNetworkId", () => {
+    it("returns the network ID", () => {
+      expect(faucetTransaction.getNetworkId()).toBe(networkId);
+    });
+  });
+
+  describe("#getAddressId", () => {
+    it("returns the transaction to address ID", () => {
+      expect(faucetTransaction.getAddressId()).toBe(toAddressId);
+    });
   });
 });

--- a/src/tests/transaction_test.ts
+++ b/src/tests/transaction_test.ts
@@ -209,34 +209,49 @@ describe("Transaction", () => {
   });
 
   describe("#getStatus", () => {
-    it("should return undefined when the transaction has not been initiated with a model", async () => {
-      model.status = "";
-      const transaction = new Transaction(model);
-      expect(transaction.getStatus()).toBeUndefined();
+    [
+      {status: TransactionStatus.PENDING, expected: "pending"},
+      {status: TransactionStatus.BROADCAST, expected: "broadcast"},
+      {status: TransactionStatus.SIGNED, expected: "signed"},
+      {status: TransactionStatus.COMPLETE, expected: "complete"},
+      {status: TransactionStatus.FAILED, expected: "failed"},
+    ].forEach(({status, expected}) => {
+      describe(`when the status is ${status}`, () => {
+        beforeEach(() => model.status = status);
+
+        it(`should return ${expected}`, () => {
+          const transaction = new Transaction(model);
+
+          expect(transaction.getStatus()).toEqual(expected);
+        });
+      });
+    });
+  });
+
+  describe("#isTerminalState", () => {
+    [
+      TransactionStatus.PENDING,
+      TransactionStatus.BROADCAST,
+      TransactionStatus.SIGNED,
+    ].forEach((status) => {
+      it(`should return false when the status is ${status}`, () => {
+        model.status = status;
+        const transaction = new Transaction(model);
+
+        expect(transaction.isTerminalState()).toEqual(false);
+      });
     });
 
-    it("should return a pending status", () => {
-      model.status = TransactionStatus.PENDING;
-      const transaction = new Transaction(model);
-      expect(transaction.getStatus()).toEqual("pending");
-    });
+    [
+      TransactionStatus.COMPLETE,
+      TransactionStatus.FAILED,
+    ].forEach((status) => {
+      it(`should return true when the status is ${status}`, () => {
+        model.status = status;
+        const transaction = new Transaction(model);
 
-    it("should return a broadcast status", () => {
-      model.status = TransactionStatus.BROADCAST;
-      const transaction = new Transaction(model);
-      expect(transaction.getStatus()).toEqual("broadcast");
-    });
-
-    it("should return a complete status", () => {
-      model.status = TransactionStatus.COMPLETE;
-      const transaction = new Transaction(model);
-      expect(transaction.getStatus()).toEqual("complete");
-    });
-
-    it("should return a failed status", () => {
-      model.status = TransactionStatus.FAILED;
-      const transaction = new Transaction(model);
-      expect(transaction.getStatus()).toEqual("failed");
+        expect(transaction.isTerminalState()).toEqual(true);
+      });
     });
   });
 

--- a/src/tests/transaction_test.ts
+++ b/src/tests/transaction_test.ts
@@ -2,6 +2,7 @@ import { ethers } from "ethers";
 import { Transaction as TransactionModel, EthereumTransaction } from "../client/api";
 import { Transaction } from "./../coinbase/transaction";
 import { TransactionStatus } from "../coinbase/types";
+import { Coinbase } from "../coinbase/coinbase";
 
 describe("Transaction", () => {
   let fromKey;
@@ -17,6 +18,7 @@ describe("Transaction", () => {
   let onchainModel;
   let blockHash;
   let blockHeight;
+  let networkID;
 
   beforeEach(() => {
     fromKey = ethers.Wallet.createRandom();
@@ -43,15 +45,18 @@ describe("Transaction", () => {
     ethereumContent = {
       priority_fee_per_gas: 1000,
     } as EthereumTransaction;
+    networkID = Coinbase.networks.BaseSepolia;
 
     model = {
       status: "pending",
+      network_id: networkID,
       from_address_id: fromAddressId,
       unsigned_payload: unsignedPayload,
     } as TransactionModel;
 
     broadcastedModel = {
       status: "broadcast",
+      network_id: networkID,
       from_address_id: fromAddressId,
       unsigned_payload: unsignedPayload,
       signed_payload: signedPayload,
@@ -61,6 +66,7 @@ describe("Transaction", () => {
 
     onchainModel = {
       status: "complete",
+      network_id: networkID,
       from_address_id: fromAddressId,
       unsigned_payload: "",
       block_hash: blockHash,
@@ -109,6 +115,12 @@ describe("Transaction", () => {
     });
   });
 
+  describe("#getNetworkId", () => {
+    it("should return the network ID", () => {
+      expect(transaction.getNetworkId()).toEqual(networkID);
+    });
+  });
+
   describe("#getRawTransaction", () => {
     let raw: ethers.Transaction, rawPayload;
 
@@ -116,6 +128,7 @@ describe("Transaction", () => {
       raw = transaction.rawTransaction();
       rawPayload = JSON.parse(Buffer.from(unsignedPayload, "hex").toString());
     });
+
     it("should return the raw transaction", () => {
       expect(raw).toBeInstanceOf(ethers.Transaction);
     });

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -10,6 +10,7 @@ import {
   AddressBalanceList,
   Address as AddressModel,
   Transfer as TransferModel,
+  FaucetTransaction as FaucetTransactionModel,
   StakingOperation as StakingOperationModel,
   PayloadSignature as PayloadSignatureModel,
   PayloadSignatureList,
@@ -252,7 +253,7 @@ export const MINT_NFT_ARGS = { recipient: "0x475d41de7A81298Ba263184996800CBcaAD
 
 const faucetTxHash = generateRandomHash(64);
 
-export const VALID_FAUCET_TRANSACTION_MODEL = {
+export const VALID_FAUCET_TRANSACTION_MODEL: FaucetTransactionModel  = {
   transaction_hash: faucetTxHash,
   transaction_link: "https://sepolia.basescan.org/tx/" + faucetTxHash,
   transaction: {
@@ -641,6 +642,7 @@ export const externalAddressApiMock = {
   getExternalAddressBalance: jest.fn(),
   requestExternalFaucetFunds: jest.fn(),
   listAddressTransactions: jest.fn(),
+  getFaucetTransaction: jest.fn(),
 };
 
 export const balanceHistoryApiMock = {

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -250,6 +250,21 @@ export const MINT_NFT_ABI = [
 
 export const MINT_NFT_ARGS = { recipient: "0x475d41de7A81298Ba263184996800CBcaAD73C0b" };
 
+const faucetTxHash = generateRandomHash(64);
+
+export const VALID_FAUCET_TRANSACTION_MODEL = {
+  transaction_hash: faucetTxHash,
+  transaction_link: "https://sepolia.basescan.org/tx/" + faucetTxHash,
+  transaction: {
+    network_id: Coinbase.networks.BaseSepolia,
+    from_address_id: ethers.Wallet.createRandom().address,
+    unsigned_payload: "",
+    transaction_hash: faucetTxHash,
+    transaction_link: "https://sepolia.basescan.org/tx/" + faucetTxHash,
+    status: TransactionStatusEnum.Pending,
+  },
+};
+
 export const VALID_CONTRACT_INVOCATION_MODEL: ContractInvocationModel = {
   wallet_id: walletId,
   address_id: ethers.Wallet.createRandom().address,

--- a/src/tests/wallet_address_test.ts
+++ b/src/tests/wallet_address_test.ts
@@ -228,6 +228,7 @@ describe("WalletAddress", () => {
         address.getNetworkId(),
         address.getId(),
         undefined,
+        true, // Skip wait should be true.
       );
 
       expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds)
@@ -244,6 +245,7 @@ describe("WalletAddress", () => {
         address.getNetworkId(),
         address.getId(),
         "usdc",
+        true, // Skip wait should be true.
       );
 
       expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds)
@@ -261,6 +263,7 @@ describe("WalletAddress", () => {
         address.getNetworkId(),
         address.getId(),
         undefined,
+        true, // Skip wait should be true.
       );
 
       expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds)

--- a/src/tests/wallet_address_test.ts
+++ b/src/tests/wallet_address_test.ts
@@ -39,6 +39,7 @@ import {
   transfersApiMock,
   VALID_ADDRESS_BALANCE_LIST,
   VALID_ADDRESS_MODEL,
+  VALID_FAUCET_TRANSACTION_MODEL,
   VALID_TRANSFER_MODEL,
   VALID_WALLET_MODEL,
   VALID_PAYLOAD_SIGNATURE_MODEL,
@@ -99,9 +100,6 @@ describe("WalletAddress", () => {
     });
     Coinbase.apiClients.externalAddress.listExternalAddressBalances = mockFn(() => {
       return { data: VALID_ADDRESS_BALANCE_LIST };
-    });
-    Coinbase.apiClients.externalAddress.requestExternalFaucetFunds = mockFn(() => {
-      return { data: { transaction_hash: transactionHash } };
     });
   });
 
@@ -211,67 +209,83 @@ describe("WalletAddress", () => {
     );
   });
 
-  it("should request funds from the faucet and returns the faucet transaction", async () => {
-    const faucetTransaction = await address.faucet();
-    expect(faucetTransaction).toBeInstanceOf(FaucetTransaction);
-    expect(faucetTransaction.getTransactionHash()).toBe(transactionHash);
-    expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledWith(
-      address.getNetworkId(),
-      address.getId(),
-      undefined,
-    );
-    expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledTimes(
-      1,
-    );
-  });
+  describe("#faucet", () => {
+    let faucetTransaction: FaucetTransaction;
 
-  it("should request funds from the faucet and returns the faucet transaction for usdc", async () => {
-    const faucetTransaction = await address.faucet("usdc");
-    expect(faucetTransaction).toBeInstanceOf(FaucetTransaction);
-    expect(faucetTransaction.getTransactionHash()).toBe(transactionHash);
-    expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledWith(
-      address.getNetworkId(),
-      address.getId(),
-      "usdc",
-    );
-    expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledTimes(
-      1,
-    );
-  });
+    beforeEach(() => {
+      Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds = mockReturnValue(VALID_FAUCET_TRANSACTION_MODEL);
+    });
 
-  it("should throw an APIError when the request is unsuccessful", async () => {
-    Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds = mockReturnRejectedValue(
-      new APIError(""),
-    );
-    await expect(address.faucet()).rejects.toThrow(APIError);
-    expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledWith(
-      address.getNetworkId(),
-      address.getId(),
-      undefined,
-    );
-    expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledTimes(
-      1,
-    );
-  });
+    it("returns the faucet transaction", async () => {
+      const faucetTransaction = await address.faucet();
 
-  it("should throw a FaucetLimitReachedError when the faucet limit is reached", async () => {
-    Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds = mockReturnRejectedValue(
-      new FaucetLimitReachedError(""),
-    );
-    await expect(address.faucet()).rejects.toThrow(FaucetLimitReachedError);
-    expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledTimes(
-      1,
-    );
-  });
+      expect(faucetTransaction).toBeInstanceOf(FaucetTransaction);
 
-  it("should throw an Error when the request fails unexpectedly", async () => {
-    Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds = mockReturnRejectedValue(
-      new Error(""),
-    );
-    await expect(address.faucet()).rejects.toThrow(Error);
-    expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledTimes(
-      1,
-    );
+      expect(faucetTransaction.getTransactionHash())
+        .toBe(VALID_FAUCET_TRANSACTION_MODEL.transaction!.transaction_hash);
+
+      expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledWith(
+        address.getNetworkId(),
+        address.getId(),
+        undefined,
+      );
+
+      expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it("returns the faucet transaction when specifying the asset ID", async () => {
+      const faucetTransaction = await address.faucet("usdc");
+
+      expect(faucetTransaction.getTransactionHash())
+        .toBe(VALID_FAUCET_TRANSACTION_MODEL.transaction!.transaction_hash);
+
+      expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledWith(
+        address.getNetworkId(),
+        address.getId(),
+        "usdc",
+      );
+
+      expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw an APIError when the request is unsuccessful", async () => {
+      Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds = mockReturnRejectedValue(
+        new APIError(""),
+      );
+
+      await expect(address.faucet()).rejects.toThrow(APIError);
+
+      expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledWith(
+        address.getNetworkId(),
+        address.getId(),
+        undefined,
+      );
+
+      expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds)
+        .toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw a FaucetLimitReachedError when the faucet limit is reached", async () => {
+      Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds = mockReturnRejectedValue(
+        new FaucetLimitReachedError(""),
+      );
+      await expect(address.faucet()).rejects.toThrow(FaucetLimitReachedError);
+      expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
+    it("should throw an Error when the request fails unexpectedly", async () => {
+      Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds = mockReturnRejectedValue(
+        new Error(""),
+      );
+      await expect(address.faucet()).rejects.toThrow(Error);
+      expect(Coinbase.apiClients.externalAddress!.requestExternalFaucetFunds).toHaveBeenCalledTimes(
+        1,
+      );
+    });
   });
 
   it("should return the correct string representation", () => {

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -7,6 +7,7 @@ import { Coinbase } from "../coinbase/coinbase";
 import { ArgumentError } from "../coinbase/errors";
 import { Wallet } from "../coinbase/wallet";
 import { Transfer } from "../coinbase/transfer";
+import { FaucetTransaction } from "../coinbase/faucet_transaction";
 import { ServerSignerStatus, StakeOptionsMode, TransferStatus } from "../coinbase/types";
 import {
   AddressBalanceList,
@@ -48,6 +49,7 @@ import {
   walletStakeApiMock,
   MINT_NFT_ABI,
   MINT_NFT_ARGS,
+  VALID_FAUCET_TRANSACTION_MODEL,
   VALID_SIGNED_PAYLOAD_SIGNATURE_MODEL,
   VALID_SIGNED_CONTRACT_INVOCATION_MODEL,
   VALID_SMART_CONTRACT_ERC20_MODEL,
@@ -589,6 +591,38 @@ describe("Wallet Class", () => {
 
       expect(contractInvocation).toBeInstanceOf(ContractInvocation);
       expect(contractInvocation).toEqual(expectedInvocation);
+    });
+  });
+
+  describe("#faucet", () => {
+    let expectedFaucetTx;
+
+    beforeEach(async () => {
+      expectedFaucetTx = new FaucetTransaction(VALID_FAUCET_TRANSACTION_MODEL);
+
+      (await wallet.getDefaultAddress()).faucet = jest
+        .fn()
+        .mockResolvedValue(expectedFaucetTx);
+    });
+
+    it("successfully requests faucet funds", async () => {
+      const faucetTx = await wallet.faucet();
+
+      expect((await wallet.getDefaultAddress()).faucet).toHaveBeenCalledTimes(1);
+      expect((await wallet.getDefaultAddress()).faucet).toHaveBeenCalledWith(undefined);
+
+      expect(faucetTx).toBeInstanceOf(FaucetTransaction);
+      expect(faucetTx).toEqual(expectedFaucetTx);
+    });
+
+    it("successfully requests faucet funds with an asset specified", async () => {
+      const faucetTx = await wallet.faucet("usdc");
+
+      expect((await wallet.getDefaultAddress()).faucet).toHaveBeenCalledTimes(1);
+      expect((await wallet.getDefaultAddress()).faucet).toHaveBeenCalledWith("usdc");
+
+      expect(faucetTx).toBeInstanceOf(FaucetTransaction);
+      expect(faucetTx).toEqual(expectedFaucetTx);
     });
   });
 


### PR DESCRIPTION
### What changed? Why?
This makes it so that our faucet transactions will be created on the server-side without waiting for confirmation and then will be able to be waited-on / polled from the SDK.

This allows us to have more stable faucet implementations (since there are fewer persistent connections across multiple services / clients) and will return a resource that can be more useful on the SDK side of things.

### How was this tested?

```
ts-node

> import { Coinbase, Wallet } from "./src/index";
> Coinbase.configureFromJson({ filePath: "..." });

> const wallet = await Wallet.create();

> const faucetTx = await wallet.faucet();

> await faucetTx.wait();
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
This makes it so that when you call `wallet.faucet()` or `address.faucet()`  it returns a faucet transaction that is not necessarily confirmed yet.