### PR TITLE
Fix Asset fromModel bug to use passed in asset_id when initializing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Fixed a bug where the asset ID was not being set correctly for Gwei and Wei
+
 ## [0.10.0] - 2024-10-31
 
 ### Added

--- a/src/coinbase/asset.ts
+++ b/src/coinbase/asset.ts
@@ -64,7 +64,12 @@ export class Asset {
           throw new ArgumentError(`Invalid asset ID: ${assetId}`);
       }
     }
-    return new Asset(model.network_id, assetId ?? model.asset_id, model.contract_address!, decimals);
+    return new Asset(
+      model.network_id,
+      assetId ?? model.asset_id,
+      model.contract_address!,
+      decimals,
+    );
   }
 
   /**

--- a/src/coinbase/asset.ts
+++ b/src/coinbase/asset.ts
@@ -64,7 +64,7 @@ export class Asset {
           throw new ArgumentError(`Invalid asset ID: ${assetId}`);
       }
     }
-    return new Asset(model.network_id, model.asset_id, model.contract_address!, decimals);
+    return new Asset(model.network_id, assetId ?? model.asset_id, model.contract_address!, decimals);
   }
 
   /**

--- a/src/tests/asset_test.ts
+++ b/src/tests/asset_test.ts
@@ -24,25 +24,29 @@ describe("Asset", () => {
     });
 
     describe("when the asset_id is gwei", () => {
-      it("should set the decimals to 9", () => {
+      it("should set the decimals to 9 and assetId to gwei", () => {
         const model = {
           asset_id: "eth",
           network_id: Coinbase.networks.BaseSepolia,
           contract_address: "0x",
           decimals: 18,
         };
-        expect(Asset.fromModel(model, Coinbase.assets.Gwei).decimals).toEqual(GWEI_DECIMALS);
+        const asset = Asset.fromModel(model, Coinbase.assets.Gwei);
+        expect(asset.decimals).toEqual(GWEI_DECIMALS);
+        expect(asset.getAssetId()).toEqual("gwei");
       });
     });
     describe("when the asset_id is wei", () => {
-      it("should set the decimals to 0", () => {
+      it("should set the decimals to 0 and assetId to wei", () => {
         const model = {
           asset_id: "eth",
           network_id: Coinbase.networks.BaseSepolia,
           contract_address: "0x",
           decimals: 18,
         };
-        expect(Asset.fromModel(model, Coinbase.assets.Wei).decimals).toEqual(0);
+        const asset = Asset.fromModel(model, Coinbase.assets.Wei);
+        expect(asset.decimals).toEqual(0);
+        expect(asset.getAssetId()).toEqual("wei");
       });
     });
   });


### PR DESCRIPTION
### What changed? Why?
See https://github.com/coinbase/cdp-sdk-python/pull/46 for context. This is the fix for the Node SDK

### Testing
- Unit tests failed when I asserted the asset ID, and then succeeded after I put the fix in.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
