### PR TITLE
feat: add staking e2e tests

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -19,4 +19,9 @@ jobs:
         NAME: ${{ secrets.NAME }}
         PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
         WALLET_DATA: ${{ secrets.WALLET_DATA }}
+        STAKE_API_KEY_NAME: ${{ secrets.STAKE_API_KEY_NAME }}
+        STAKE_API_PRIVATE_KEY: ${{ secrets.STAKE_API_PRIVATE_KEY }}
+        STAKE_ADDRESS_ID_1: ${{ secrets.STAKE_ADDRESS_ID_1 }}
+        STAKE_ADDRESS_ID_2: ${{ secrets.STAKE_ADDRESS_ID_2 }}
+        STAKE_VALIDATOR_ADDRESS_1: ${{ secrets.STAKE_VALIDATOR_ADDRESS_1 }}
       run: npm run test:dry-run && npm run test:e2e

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "npx jest --no-cache  --testMatch=**/*_test.ts",
     "test:dry-run": "npm install && npm ci && npm publish --dry-run",
     "test:e2e": "npx jest --no-cache --testMatch=**/e2e.ts --coverageThreshold '{}'",
+    "test:e2e:stake": "npx jest --no-cache --testMatch=**/e2e.ts --coverageThreshold '{}' -t Stake",
     "test:types": "tsd --files src/tests/types.test-d.ts",
     "clean": "rm -rf dist/*",
     "build": "tsc",

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -1,6 +1,18 @@
 import fs from "fs";
 import dotenv from "dotenv";
-import { Coinbase, Wallet } from "../index";
+import {
+  Coinbase,
+  Wallet,
+  StakingReward,
+  StakingBalance,
+  ExternalAddress,
+  ValidatorStatus,
+  Validator,
+  StakeOptionsMode,
+  TransactionStatus,
+} from "../index";
+
+import { StakingOperationStatusEnum } from "../client";
 import { TransferStatus } from "../coinbase/types";
 
 describe("Coinbase SDK E2E Test", () => {
@@ -128,4 +140,211 @@ describe("Coinbase SDK E2E Test", () => {
       iv: "",
     });
   }, 60000);
+});
+
+describe("Coinbase SDK Stake E2E Test", () => {
+  const requiredEnvVars = [
+    "STAKE_API_KEY_NAME",
+    "STAKE_API_PRIVATE_KEY",
+    "STAKE_ADDRESS_ID_1",
+    "STAKE_ADDRESS_ID_2",
+    "STAKE_VALIDATOR_ADDRESS_1",
+  ];
+
+  beforeAll(() => {
+    dotenv.config();
+
+    requiredEnvVars.forEach(envVar => {
+      if (!process.env[envVar]) {
+        throw new Error(`Required environment variable ${envVar} is not set`);
+      }
+    });
+
+    Coinbase.configure({
+      apiKeyName: process.env.STAKE_API_KEY_NAME as string,
+      privateKey: process.env.STAKE_API_PRIVATE_KEY as string,
+    });
+  });
+
+  it("should be able to access environment variables", () => {
+    requiredEnvVars.forEach(envVar => {
+      expect(process.env[envVar]).toBeDefined();
+    });
+  });
+
+  describe("Stake: Reward Tests", () => {
+    it("should list shared eth staking rewards via StakingReward.list", async () => {
+      const networkId = Coinbase.networks.EthereumMainnet;
+      const assetId = Coinbase.assets.Eth;
+      const addressIds = [process.env.STAKE_ADDRESS_ID_1 as string];
+      // May 1, 2024 - May 20, 2024
+      const startTime = new Date(2024, 4, 1, 0, 0, 0).toISOString();
+      const endTime = new Date(2024, 4, 20, 23, 59, 59).toISOString();
+      const rewards = await StakingReward.list(networkId, assetId, addressIds, startTime, endTime);
+
+      expect(rewards).toBeDefined();
+      expect(rewards.length).toEqual(20);
+    });
+
+    it("should list shared eth staking rewards via ExternalAddress", async () => {
+      // May 1, 2024 - May 20, 2024
+      const startTime = new Date(2024, 4, 1, 0, 0, 0).toISOString();
+      const endTime = new Date(2024, 4, 20, 23, 59, 59).toISOString();
+
+      const address = new ExternalAddress(
+        Coinbase.networks.EthereumMainnet,
+        process.env.STAKE_ADDRESS_ID_1 as string,
+      );
+
+      const rewards = await address.stakingRewards(Coinbase.assets.Eth, startTime, endTime);
+
+      expect(rewards).toBeDefined();
+      expect(rewards.length).toEqual(20);
+    });
+  });
+
+  describe("Stake: Balance Tests", () => {
+    it("should list shared eth staking balances via StakingBalance.list", async () => {
+      const networkId = Coinbase.networks.EthereumMainnet;
+      const assetId = Coinbase.assets.Eth;
+      const addressId = process.env.STAKE_VALIDATOR_ADDRESS_1 as string;
+      // Nov 1, 2024 - Nov 20, 2024
+      const startTime = new Date(2024, 10, 1, 0, 0, 0).toISOString();
+      const endTime = new Date(2024, 10, 20, 23, 59, 59).toISOString();
+      const stakingBalances = await StakingBalance.list(
+        networkId,
+        assetId,
+        addressId,
+        startTime,
+        endTime,
+      );
+
+      expect(stakingBalances).toBeDefined();
+      expect(stakingBalances.length).toEqual(20);
+    });
+  });
+
+  describe("Stake: Validator Tests", () => {
+    it("should list validators", async () => {
+      const networkId = Coinbase.networks.EthereumMainnet;
+      const assetId = Coinbase.assets.Eth;
+      const status = ValidatorStatus.ACTIVE;
+
+      const validators = await Validator.list(networkId, assetId, status);
+
+      expect(validators).toBeDefined();
+      expect(validators.length).toEqual(1);
+      const validator = validators[0];
+      expect(validator.getStatus()).toEqual(ValidatorStatus.ACTIVE);
+      expect(validator.getValidatorId()).toEqual(process.env.STAKE_VALIDATOR_ADDRESS_1 as string);
+    });
+
+    it("should fetch a validator", async () => {
+      const networkId = Coinbase.networks.EthereumMainnet;
+      const assetId = Coinbase.assets.Eth;
+      const validatorId = process.env.STAKE_VALIDATOR_ADDRESS_1 as string;
+
+      const validator = await Validator.fetch(networkId, assetId, validatorId);
+
+      expect(validator).toBeDefined();
+      expect(validator.getStatus()).toEqual(ValidatorStatus.ACTIVE);
+      expect(validator.getValidatorId()).toEqual(validatorId);
+    });
+  });
+
+  describe("Stake: Context Tests", () => {
+    it("should return stakeable balances for shared ETH staking", async () => {
+      const address = new ExternalAddress(
+        Coinbase.networks.EthereumMainnet,
+        process.env.STAKE_ADDRESS_ID_2 as string,
+      );
+
+      const stakeableBalance = await address.stakeableBalance(
+        Coinbase.assets.Eth,
+        StakeOptionsMode.PARTIAL,
+      );
+
+      expect(stakeableBalance).toBeDefined();
+      expect(stakeableBalance.toNumber()).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should return unstakeable balances for shared ETH staking", async () => {
+      const address = new ExternalAddress(
+        Coinbase.networks.EthereumMainnet,
+        process.env.STAKE_ADDRESS_ID_1 as string,
+      );
+
+      const stakeableBalance = await address.unstakeableBalance(
+        Coinbase.assets.Eth,
+        StakeOptionsMode.PARTIAL,
+      );
+
+      expect(stakeableBalance).toBeDefined();
+      expect(stakeableBalance.toNumber()).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should return claimable balances for shared ETH staking", async () => {
+      const address = new ExternalAddress(
+        Coinbase.networks.EthereumMainnet,
+        process.env.STAKE_ADDRESS_ID_1 as string,
+      );
+
+      const stakeableBalance = await address.claimableBalance(
+        Coinbase.assets.Eth,
+        StakeOptionsMode.PARTIAL,
+      );
+
+      expect(stakeableBalance).toBeDefined();
+      expect(stakeableBalance.toNumber()).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should return unstakeable balances for Dedicated ETH staking", async () => {
+      // This address is expected to have 1 validator associated with it, thus returning a 32 unstake balance.
+
+      const address = new ExternalAddress(
+        Coinbase.networks.EthereumMainnet,
+        process.env.STAKE_ADDRESS_ID_2 as string,
+      );
+
+      const stakeableBalance = await address.unstakeableBalance(
+        Coinbase.assets.Eth,
+        StakeOptionsMode.NATIVE,
+      );
+
+      expect(stakeableBalance).toBeDefined();
+      expect(stakeableBalance.toNumber()).toBeGreaterThanOrEqual(32);
+    });
+  });
+
+  describe("Stake: Build Tests", () => {
+    it("should return an unsigned tx for shared ETH staking", async () => {
+      const address = new ExternalAddress(
+        Coinbase.networks.EthereumHolesky,
+        process.env.STAKE_ADDRESS_ID_2 as string,
+      );
+
+      const stakingOperation = await address.buildStakeOperation(
+        0.0001,
+        Coinbase.assets.Eth,
+        StakeOptionsMode.PARTIAL,
+      );
+
+      await stakingOperation.wait({ timeoutSeconds: 5, intervalSeconds: 1 });
+
+      expect(stakingOperation).toBeDefined();
+      expect(stakingOperation.getID()).toBeDefined();
+      expect(stakingOperation.getStatus()).toEqual(StakingOperationStatusEnum.Complete);
+      expect(stakingOperation.getAddressID()).toEqual(process.env.STAKE_ADDRESS_ID_2 as string);
+      expect(stakingOperation.getNetworkID()).toEqual(Coinbase.networks.EthereumHolesky);
+      expect(stakingOperation.isCompleteState()).toBe(true);
+      expect(stakingOperation.getSignedVoluntaryExitMessages()).toEqual([]);
+      expect(stakingOperation.getTransactions().length).toEqual(1);
+      expect(stakingOperation.getTransactions()[0].isSigned()).toBe(false);
+      expect(stakingOperation.getTransactions()[0].getNetworkId()).toEqual(
+        Coinbase.networks.EthereumHolesky,
+      );
+      expect(stakingOperation.getTransactions()[0].getUnsignedPayload()).toBeDefined();
+      expect(stakingOperation.getTransactions()[0].getStatus()).toEqual(TransactionStatus.PENDING);
+    });
+  });
 });


### PR DESCRIPTION
### What changed? Why?

This PR attempts to introduce some basic staking related e2e tests and to integrate with our internal testing workflows.

Plan is to follow up on this and add many more tests around testing different implementations, networks etc.

Have tried to do it in a way where every product/scope can come and add their specific env vars and tests. As a result 

1. Chose to prefix staking related env vars with prefix `STAKE`.
2. Made sure all staking related tests sit under a single test suite implemented via a describe section.
3. Added an explicit npm script `test:e2e:stake` to be able to run scope specific tests.

### Testing

Tested locally and made sure it's running fine in CI.

```
>> npm run test:e2e:stake

> @coinbase/coinbase-sdk@0.10.0 test:e2e:stake
> npx jest --no-cache --testMatch=**/e2e.ts --coverageThreshold '{}' -t Stake

 PASS  src/tests/e2e.ts (7.926 s)
  Coinbase SDK E2E Test
    ○ skipped should be able to access environment variables
    ○ skipped should have created a dist folder for NPM
    ○ skipped should be able to interact with the Coinbase SDK
  Coinbase SDK Stake E2E Test
    ✓ should be able to access environment variables (1 ms)
    Stake: Reward Tests
      ✓ should list shared eth staking rewards via StakingReward.list (607 ms)
      ✓ should list shared eth staking rewards via ExternalAddress (416 ms)
    Stake: Balance Tests
      ✓ should list shared eth staking balances via StakingBalance.list (367 ms)
    Stake: Validator Tests
      ✓ should list validators (654 ms)
      ✓ should fetch a validator (434 ms)
    Stake: Context Tests
      ✓ should return stakeable balances for shared ETH staking (403 ms)
      ✓ should return unstakeable balances for shared ETH staking (429 ms)
      ✓ should return claimable balances for shared ETH staking (424 ms)
      ✓ should return unstakeable balances for Dedicated ETH staking (515 ms)
    Stake: Build Tests
      ✓ should return an unsigned tx for shared ETH staking (1138 ms)

Test Suites: 1 passed, 1 total
Tests:       3 skipped, 11 passed, 14 total
Snapshots:   0 total
Time:        8.125 s
Ran all test suites with tests matching "Stake".
```


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
