### PR TITLE
feat: update client to include rlp_encoded_tx 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - Fixed a bug where the asset ID was not being set correctly for Gwei and Wei
 
+### Added
+- Add `rlp_encoded_tx` field to `EthereumTransaction` interface
+
 ## [0.10.0] - 2024-10-31
 
 ### Added

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1357,6 +1357,12 @@ export interface EthereumTransaction {
      * @memberof EthereumTransaction
      */
     'mint'?: string;
+    /**
+     * RLP encoded transaction as a hex string (prefixed with 0x) for native compatibility with popular eth clients such as etherjs, viem etc.
+     * @type {string}
+     * @memberof EthereumTransaction
+     */
+    'rlp_encoded_tx'?: string;
 }
 /**
  * 


### PR DESCRIPTION
### What changed? Why?

Update auto-generated client to include `rlp_encoded_tx` field within EthereumTransaction

### Testing

```
>> npx ts-node --project tsconfig.json
> import { Coinbase, ExternalAddress, StakingReward, StakeOptionsMode, Validator, ValidatorStatus, Transaction, Asset, Wallet } from "./src";
undefined
> import { ethers } from "ethers";
undefined
> import axios from 'axios';
undefined
>
undefined
>
undefined
> const coinbase = Coinbase.configureFromJson({ filePath: "MY_KEY_PATH" });
undefined
>
undefined
> let ea = new ExternalAddress("ethereum-holesky", "0x87Bf57c3d7B211a100ee4d00dee08435130A62fA");
undefined
> let stakeOperation = await ea.buildStakeOperation(0.0001, "eth", StakeOptionsMode.PARTIAL);
undefined
> let tx = stakeOperation.getTransactions()[0];
undefined
> tx.content()!
{
  from: '0x87Bf57c3d7B211a100ee4d00dee08435130A62fA',
  gas: 300000,
  gas_price: 10000000032,
  hash: '0x2eea35130bef61142de193cc0c87d860f3bb9f2f2e34ddc5548bceaf70d5cb2b',
  input: '0x3a4b66f1',
  max_fee_per_gas: 10000000032,
  max_priority_fee_per_gas: 10000000000,
  nonce: 320,
  rlp_encoded_tx: '0x02f83b8242688201408502540be4008502540be420830493e094a55416de5de61a0ac1aa8970a280e04388b1de4b865af3107a4000843a4b66f1c0808080',
  to: '0xA55416de5DE61A0AC1aa8970a280E04388B1dE4b',
  type: 2,
  value: '100000000000000'
}
> tx.content()!.rlp_encoded_tx
'0x02f83b8242688201408502540be4008502540be420830493e094a55416de5de61a0ac1aa8970a280e04388b1de4b865af3107a4000843a4b66f1c0808080'
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
