### PR TITLE
feat: Add source & source version attribution

### DIFF
--- a/src/coinbase/authenticator.ts
+++ b/src/coinbase/authenticator.ts
@@ -12,16 +12,22 @@ const pemFooter = "-----END EC PRIVATE KEY-----";
 export class CoinbaseAuthenticator {
   private apiKey: string;
   private privateKey: string;
+  private source: string;
+  private sourceVersion?: string;
 
   /**
    * Initializes the Authenticator.
    *
    * @param {string} apiKey - The API key name.
    * @param {string} privateKey - The private key associated with the API key.
+   * @param {string} source - The source of the request.
+   * @param {string} sourceVersion - The version of the source.
    */
-  constructor(apiKey: string, privateKey: string) {
+  constructor(apiKey: string, privateKey: string, source: string, sourceVersion?: string) {
     this.apiKey = apiKey;
     this.privateKey = privateKey;
+    this.source = source;
+    this.sourceVersion = sourceVersion;
   }
 
   /**
@@ -140,7 +146,12 @@ export class CoinbaseAuthenticator {
     const data = {
       sdk_version: version,
       sdk_language: "typescript",
+      source: this.source,
     };
+
+    if (this.sourceVersion) {
+      data["source_version"] = this.sourceVersion;
+    }
 
     return Object.keys(data)
       .map(key => `${key}=${encodeURIComponent(data[key])}`)

--- a/src/coinbase/coinbase.ts
+++ b/src/coinbase/coinbase.ts
@@ -94,6 +94,8 @@ export class Coinbase {
    * @param options.debugging - If true, logs API requests and responses to the console.
    * @param options.basePath - The base path for the API.
    * @param options.maxNetworkRetries - The maximum number of network retries for the API GET requests.
+   * @param options.source - Optional source string to be sent with the API requests. Defaults to `sdk`.
+   * @param options.sourceVersion - Optional source version string to be sent with the API requests.
    * @throws {InvalidConfigurationError} If the configuration is invalid.
    * @throws {InvalidAPIKeyFormatError} If not able to create JWT token.
    */
@@ -104,6 +106,8 @@ export class Coinbase {
     debugging = false,
     basePath = BASE_PATH,
     maxNetworkRetries = 3,
+    source = "sdk",
+    sourceVersion = undefined,
   }: CoinbaseOptions) {
     if (apiKeyName === "") {
       throw new InvalidConfigurationError("Invalid configuration: apiKeyName is empty");
@@ -111,7 +115,12 @@ export class Coinbase {
     if (privateKey === "") {
       throw new InvalidConfigurationError("Invalid configuration: privateKey is empty");
     }
-    const coinbaseAuthenticator = new CoinbaseAuthenticator(apiKeyName, privateKey);
+    const coinbaseAuthenticator = new CoinbaseAuthenticator(
+      apiKeyName,
+      privateKey,
+      source,
+      sourceVersion,
+    );
     const config = new Configuration({
       basePath: basePath,
     });

--- a/src/coinbase/coinbase.ts
+++ b/src/coinbase/coinbase.ts
@@ -207,6 +207,8 @@ export class Coinbase {
    * @param options.useServerSigner - Whether to use a Server-Signer or not.
    * @param options.debugging - If true, logs API requests and responses to the console.
    * @param options.basePath - The base path for the API.
+   * @param options.source - Optional source string to be sent with the API requests. Defaults to `sdk`.
+   * @param options.sourceVersion - Optional source version string to be sent with the API requests.
    * @returns A new instance of the Coinbase SDK.
    * @throws {InvalidAPIKeyFormat} If the file does not exist or the configuration values are missing/invalid.
    * @throws {InvalidConfiguration} If the configuration is invalid.
@@ -217,6 +219,8 @@ export class Coinbase {
     useServerSigner = false,
     debugging = false,
     basePath = BASE_PATH,
+    source = "sdk",
+    sourceVersion = undefined,
   }: CoinbaseConfigureFromJsonOptions = {}): Coinbase {
     filePath = filePath.startsWith("~") ? filePath.replace("~", os.homedir()) : filePath;
 
@@ -236,6 +240,8 @@ export class Coinbase {
         useServerSigner: useServerSigner,
         debugging: debugging,
         basePath: basePath,
+        source,
+        sourceVersion,
       });
     } catch (e) {
       if (e instanceof SyntaxError) {

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -908,6 +908,16 @@ export type CoinbaseConfigureFromJsonOptions = {
    * The base path for the API.
    */
   basePath?: string;
+
+  /**
+   * The source for the API request, used for analytics. Defaults to `sdk`.
+   */
+  source?: string;
+
+  /**
+   * The version of the source for the API request, used for analytics.
+   */
+  sourceVersion?: string;
 };
 
 /**

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -873,6 +873,16 @@ export type CoinbaseOptions = {
    * The maximum number of network retries for the API GET requests.
    */
   maxNetworkRetries?: number;
+
+  /**
+   * The source for the API request, used for analytics. Defaults to `sdk`.
+   */
+  source?: string;
+
+  /**
+   * The version of the source for the API request, used for analytics.
+   */
+  sourceVersion?: string;
 };
 
 /**


### PR DESCRIPTION
### What changed? Why?
This adds the source & source version attribution handling.

This makes it so that when configuring the SDK, the `source` and `sourceVersion` can be configured and passed through as correlation context for attribution on the backend.

This will make it so we can easily attribute AgentKit requests to the specific version.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
