### PR TITLE
chore: Release 0.11.1 with Correlation Data Patch Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## [0.11.1] - 2024-11-29
+
+### Fixed
+- Support setting `source` and `sourceVersion` correlation data via `Coinbase.configure()`
+
 ## [0.11.0] - 2024-11-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "ISC",
   "description": "Coinbase Platform SDK",
   "repository": "https://github.com/coinbase/coinbase-sdk-nodejs",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/src/coinbase/coinbase.ts
+++ b/src/coinbase/coinbase.ts
@@ -183,6 +183,8 @@ export class Coinbase {
    * @param options.useServerSigner - Whether to use a Server-Signer or not. Defaults to false.
    * @param options.debugging - If true, logs API requests and responses to the console. Defaults to false.
    * @param options.basePath - The base path for the API. Defaults to BASE_PATH.
+   * @param options.source - Optional source string to be sent with the API requests. Defaults to `sdk`.
+   * @param options.sourceVersion - Optional source version string to be sent with the API requests.
    * @returns A new instance of the Coinbase SDK.
    */
   static configure({
@@ -191,6 +193,8 @@ export class Coinbase {
     useServerSigner = false,
     debugging = false,
     basePath = BASE_PATH,
+    source = "sdk",
+    sourceVersion = undefined,
   }: CoinbaseOptions) {
     return new Coinbase({
       apiKeyName,
@@ -198,6 +202,8 @@ export class Coinbase {
       useServerSigner,
       debugging,
       basePath,
+      source,
+      sourceVersion,
     });
   }
 


### PR DESCRIPTION
### What changed? Why?
- Support setting `source` and `sourceVersion` correlation data via `Coinbase.configure()`
- Release `v0.11.1`

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
