### PR TITLE
chore(PSDK-640): add networkId to WalletData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Add support for fetching address reputation
   - Add `reputation` method to `Address` to fetch the reputation of the address. 
+- Add `networkId` to `WalletData` so that it is saved with the seed data and surfaced via the export function
 
 ## [0.12.0] - Skipped
 

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -818,6 +818,7 @@ export enum FundOperationStatus {
 export type WalletData = {
   walletId: string;
   seed: string;
+  networkId: string;
 };
 
 /**
@@ -828,6 +829,7 @@ export type SeedData = {
   encrypted: boolean;
   authTag: string;
   iv: string;
+  networkId: string;
 };
 
 /**

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -221,7 +221,7 @@ export class Wallet {
     if (!this.seed) {
       throw new Error("Cannot export Wallet without loaded seed");
     }
-    return { walletId: this.getId()!, seed: this.seed };
+    return { walletId: this.getId()!, seed: this.seed, networkId: this.getNetworkId() };
   }
 
   /**
@@ -631,6 +631,7 @@ export class Wallet {
       encrypted: encrypt,
       authTag: authTag,
       iv: iv,
+      networkId: data.networkId,
     };
 
     fs.writeFileSync(filePath, JSON.stringify(existingSeedsInStore, null, 2), "utf8");

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -54,7 +54,11 @@ describe("Coinbase SDK E2E Test", () => {
     const walletId = Object.keys(seedFile)[0];
     const seed = seedFile[walletId].seed;
 
-    const importedWallet = await Wallet.import({ seed, walletId });
+    const importedWallet = await Wallet.import({
+      seed,
+      walletId,
+      networkId: Coinbase.networks.BaseSepolia,
+    });
     expect(importedWallet).toBeDefined();
     expect(importedWallet.getId()).toBe(walletId);
     console.log(
@@ -138,6 +142,7 @@ describe("Coinbase SDK E2E Test", () => {
       encrypted: false,
       authTag: "",
       iv: "",
+      networkId: exportedWallet.networkId,
     });
   }, 60000);
 });

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -1197,6 +1197,7 @@ describe("Wallet Class", () => {
       expect(walletSeedData[walletId].iv).toBe("");
       expect(walletSeedData[walletId].authTag).toBe("");
       expect(walletSeedData[walletId].seed).toBe(seed);
+      expect(walletSeedData[walletId].networkId).toBe(seedWallet.getNetworkId());
     });
 
     it("should save the seed when encryption is true", async () => {


### PR DESCRIPTION
### What changed? Why?
It should be clear which saved wallets belong to which networks when you `save_seed` / `export_data` for a given wallet.


### How i tested
After running:
```ts
const wallet = await Wallet.create({
  networkId: Coinbase.networks.BaseSepolia,
});

wallet.saveSeed("/Users/ryan/code/public/seeds/wallet_seed.json");
```

`wallet_seed.json` looks like:
```json
{
  "f737686d-c78f-4b89-9bf4-7b57559425b8": {
    "seed": "8a5xxx",
    "encrypted": false,
    "authTag": "",
    "iv": "",
    "networkId": "base-sepolia"
  }
}
```

And the result of `wallet.export()`:
```js
{
  walletId: 'f737686d-c78f-4b89-9bf4-7b57559425b8',
  seed: '8a5xxx',
  networkId: 'base-sepolia'
}
```

#### Qualified Impact
The network id should always be present, and if it is not, it will simply not be included in the WalletData