### PR TITLE
Add extra support for more getters for the Validator class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add getters for `Validator` object to expose more data to users.
+- Add test file for `Validator` object.
 
 ### [0.11.3] - 2024-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add getters for `Validator` object to expose more data to users.
+
 ### [0.11.3] - 2024-12-10
 
 ### Added

--- a/src/coinbase/validator.ts
+++ b/src/coinbase/validator.ts
@@ -5,7 +5,6 @@ import {
   ValidatorStatus as APIValidatorStatus,
 } from "../client/api";
 import { ValidatorStatus } from "./types";
-import { BalanceMap } from "./balance_map";
 
 /**
  * A representation of a validator onchain.
@@ -255,12 +254,12 @@ export class Validator {
   }
 
   /**
-   * Returns the string representation of the Validator including all its details.
+   * Returns the string representation of the Validator.
    *
-   * @returns The string representation of the Validator including all its details.
+   * @returns The string representation of the Validator.
    */
   public toString(): string {
-    return `Validator { Id: ${this.getValidatorId()}, Status: ${this.getStatus()}, Exit Epoch: ${this.getExitEpoch()}, Network ID: ${this.getNetworkId()}, Asset ID: ${this.getAssetId()}, Index: ${this.getIndex()}, Public Key: ${this.getPublicKey()}, Slashed: ${this.isSlashed()}, Withdrawable Epoch: ${this.getWithdrawableEpoch()}, Withdrawal Address: ${this.getWithdrawalAddress()}, Effective Balance: { Amount: ${this.getEffectiveBalance()?.amount}, AssetID: { ${this.getEffectiveBalance()?.asset.asset_id}, Decimals: ${this.getEffectiveBalance()?.asset.decimals}, NetworkID: ${this.getEffectiveBalance()?.asset.network_id} } }, Balance: { Amount ${this.getBalance()?.amount}, Asset: { AssetID: ${this.getBalance()?.asset.asset_id}, Decimals: ${this.getBalance()?.asset.decimals}, NetworkID: ${this.getBalance()?.asset.network_id} } }, Activation Epoch: ${this.getActivationEpoch()} }`;
+    return `Id: ${this.getValidatorId()} Status: ${this.getStatus()}`;
   }
 
   /**

--- a/src/coinbase/validator.ts
+++ b/src/coinbase/validator.ts
@@ -1,6 +1,11 @@
 import { Coinbase } from "./coinbase";
-import { Validator as ValidatorModel, ValidatorStatus as APIValidatorStatus } from "../client/api";
+import {
+  Balance,
+  Validator as ValidatorModel,
+  ValidatorStatus as APIValidatorStatus,
+} from "../client/api";
 import { ValidatorStatus } from "./types";
+import { BalanceMap } from "./balance_map";
 
 /**
  * A representation of a validator onchain.
@@ -151,11 +156,119 @@ export class Validator {
     }
   }
   /**
-   * Returns the string representation of the Validator.
+   * Returns the network ID.
    *
-   * @returns The string representation of the Validator.
+   * @returns The network ID.
+   */
+  public getNetworkId(): string {
+    return this.model.network_id;
+  }
+
+  /**
+   * Returns the asset ID.
+   *
+   * @returns The asset ID.
+   */
+  public getAssetId(): string {
+    return this.model.asset_id;
+  }
+
+  /**
+   * Returns the activation epoch of the validator.
+   *
+   * @returns The activation epoch as a string.
+   */
+  public getActivationEpoch(): string {
+    return this.model.details?.activationEpoch || "";
+  }
+
+  /**
+   * Returns the balance of the validator.
+   *
+   * @returns The balance object.
+   */
+  public getBalance(): Balance | undefined {
+    return this.model.details?.balance;
+  }
+
+  /**
+   * Returns the effective balance of the validator.
+   *
+   * @returns The effective balance object.
+   */
+  public getEffectiveBalance(): Balance | undefined {
+    return this.model.details?.effective_balance;
+  }
+
+  /**
+   * Returns the exit epoch of the validator.
+   *
+   * @returns The exit epoch as a string.
+   */
+  public getExitEpoch(): string {
+    return this.model.details?.exitEpoch || "";
+  }
+
+  /**
+   * Returns the index of the validator.
+   *
+   * @returns The validator index as a string.
+   */
+  public getIndex(): string {
+    return this.model.details?.index || "";
+  }
+
+  /**
+   * Returns the public key of the validator.
+   *
+   * @returns The validator's public key as a string.
+   */
+  public getPublicKey(): string {
+    return this.model.details?.public_key || "";
+  }
+
+  /**
+   * Returns whether the validator has been slashed.
+   *
+   * @returns True if the validator has been slashed, false otherwise.
+   */
+  public isSlashed(): boolean {
+    return this.model.details?.slashed || false;
+  }
+
+  /**
+   * Returns the withdrawable epoch of the validator.
+   *
+   * @returns The withdrawable epoch as a string.
+   */
+  public getWithdrawableEpoch(): string {
+    return this.model.details?.withdrawableEpoch || "";
+  }
+
+  /**
+   * Returns the withdrawal address of the validator.
+   *
+   * @returns The withdrawal address as a string.
+   */
+  public getWithdrawalAddress(): string {
+    return this.model.details?.withdrawal_address || "";
+  }
+
+  /**
+   * Returns the string representation of the Validator including all its details.
+   *
+   * @returns The string representation of the Validator including all its details.
    */
   public toString(): string {
-    return `Id: ${this.getValidatorId()} Status: ${this.getStatus()}`;
+    return `Validator { Id: ${this.getValidatorId()}, Status: ${this.getStatus()}, Exit Epoch: ${this.getExitEpoch()}, Network ID: ${this.getNetworkId()}, Asset ID: ${this.getAssetId()}, Index: ${this.getIndex()}, Public Key: ${this.getPublicKey()}, Slashed: ${this.isSlashed()}, Withdrawable Epoch: ${this.getWithdrawableEpoch()}, Withdrawal Address: ${this.getWithdrawalAddress()}, Effective Balance: { Amount: ${this.getEffectiveBalance()?.amount}, AssetID: { ${this.getEffectiveBalance()?.asset.asset_id}, Decimals: ${this.getEffectiveBalance()?.asset.decimals}, NetworkID: ${this.getEffectiveBalance()?.asset.network_id} } }, Balance: { Amount ${this.getBalance()?.amount}, Asset: { AssetID: ${this.getBalance()?.asset.asset_id}, Decimals: ${this.getBalance()?.asset.decimals}, NetworkID: ${this.getBalance()?.asset.network_id} } }, Activation Epoch: ${this.getActivationEpoch()} }`;
+  }
+
+  /**
+   * Returns the JSON representation of the Validator.
+   *
+   * @returns The JSON representation of the Validator.
+   */
+  public toJSON(): string {
+    return JSON.stringify(this.model);
   }
 }

--- a/src/tests/validator_test.ts
+++ b/src/tests/validator_test.ts
@@ -1,0 +1,95 @@
+import { Validator } from "../coinbase/validator";
+import { ValidatorStatus } from "../coinbase/types";
+import { Validator as ValidatorModel } from "../client";
+import { Coinbase } from "../coinbase/coinbase";
+import { ValidatorStatus as APIValidatorStatus } from "../client/api";
+
+describe("Validator", () => {
+  let validator: Validator;
+
+  beforeEach(() => {
+    const mockModel: ValidatorModel = {
+      validator_id: "123",
+      status: APIValidatorStatus.Active,
+      network_id: Coinbase.networks.EthereumHolesky,
+      asset_id: Coinbase.assets.Eth,
+      details: {
+        effective_balance: {
+          amount: "100",
+          asset: { network_id: Coinbase.networks.EthereumHolesky, asset_id: Coinbase.assets.Eth },
+        },
+        balance: {
+          amount: "200",
+          asset: { network_id: Coinbase.networks.EthereumHolesky, asset_id: Coinbase.assets.Eth },
+        },
+        exitEpoch: "epoch-1",
+        activationEpoch: "epoch-0",
+        index: "0",
+        public_key: "public-key-123",
+        slashed: false,
+        withdrawableEpoch: "epoch-2",
+        withdrawal_address: "withdrawal-address-123",
+      },
+    };
+
+    validator = new Validator(mockModel);
+  });
+
+  test("getValidatorId should return the correct validator ID", () => {
+    expect(validator.getValidatorId()).toBe("123");
+  });
+
+  test("getStatus should return the correct status", () => {
+    expect(validator.getStatus()).toBe(ValidatorStatus.ACTIVE);
+  });
+
+  test("getNetworkId should return the correct network ID", () => {
+    expect(validator.getNetworkId()).toBe(Coinbase.networks.EthereumHolesky);
+  });
+
+  test("getAssetId should return the correct asset ID", () => {
+    expect(validator.getAssetId()).toBe(Coinbase.assets.Eth);
+  });
+
+  test("getActivationEpoch should return the correct activation epoch", () => {
+    expect(validator.getActivationEpoch()).toBe("epoch-0");
+  });
+
+  test("getExitEpoch should return the correct exit epoch", () => {
+    expect(validator.getExitEpoch()).toBe("epoch-1");
+  });
+
+  test("getIndex should return the correct index", () => {
+    expect(validator.getIndex()).toBe("0");
+  });
+
+  test("getPublicKey should return the correct public key", () => {
+    expect(validator.getPublicKey()).toBe("public-key-123");
+  });
+
+  test("isSlashed should return the correct slashed status", () => {
+    expect(validator.isSlashed()).toBe(false);
+  });
+
+  test("getWithdrawableEpoch should return the correct withdrawable epoch", () => {
+    expect(validator.getWithdrawableEpoch()).toBe("epoch-2");
+  });
+
+  test("getWithdrawalAddress should return the correct withdrawal address", () => {
+    expect(validator.getWithdrawalAddress()).toBe("withdrawal-address-123");
+  });
+
+  test("getEffectiveBalance should return the correct effective balance", () => {
+    expect(validator.getEffectiveBalance()).toEqual({
+      amount: "100",
+      asset: { network_id: Coinbase.networks.EthereumHolesky, asset_id: Coinbase.assets.Eth },
+    });
+  });
+
+  test("getBalance should return the correct balance", () => {
+    expect(validator.getBalance()).toEqual({
+      amount: "200",
+      asset: { network_id: Coinbase.networks.EthereumHolesky, asset_id: Coinbase.assets.Eth },
+    });
+  });
+});


### PR DESCRIPTION
### What changed? Why?
Adding support for more getters to expose the data behind the Validator object.

### Example
`validator.toString()`
```
'Validator { Id: 0x921018e49cf63a8573ea2e0c665d025325361b417233d6727907b205cf2c420e153060297b60dcbf6d42871cf8610d2f, Status: active, Exit Epoch: 18446744073709551615, Network ID: ethereum-holesky, Asset ID: ETH, Index: 1768213, Public Key: 0x921018e49cf63a8573ea2e0c665d025325361b417233d6727907b205cf2c420e153060297b60dcbf6d42871cf8610d2f, Slashed: false, Withdrawable Epoch: 18446744073709551615, Withdrawal Address: 0x0100000000000000000000008d082f80606b8f93827a8a8e8c1c48950be60a33, Effective Balance: { Amount: 32000000000000000000, AssetID: { eth, Decimals: 18, NetworkID: ethereum-holesky } }, Balance: { Amount 32000113927000000000, Asset: { AssetID: eth, Decimals: 18, NetworkID: ethereum-holesky } }, Activation Epoch: 67501 }'
```
`validator.toJSON()`
```
'{"asset_id":"ETH","details":{"activationEpoch":"67501","balance":{"amount":"32000113927000000000","asset":{"asset_id":"eth","decimals":18,"network_id":"ethereum-holesky"}},"effective_balance":{"amount":"32000000000000000000","asset":{"asset_id":"eth","decimals":18,"network_id":"ethereum-holesky"}},"exitEpoch":"18446744073709551615","index":"1768213","public_key":"0x921018e49cf63a8573ea2e0c665d025325361b417233d6727907b205cf2c420e153060297b60dcbf6d42871cf8610d2f","slashed":false,"withdrawableEpoch":"18446744073709551615","withdrawal_address":"0x0100000000000000000000008d082f80606b8f93827a8a8e8c1c48950be60a33"},"network_id":"ethereum-holesky","status":"active","validator_id":"0x921018e49cf63a8573ea2e0c665d025325361b417233d6727907b205cf2c420e153060297b60dcbf6d42871cf8610d2f"}'
```


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
