### PR TITLE
feat(PSDK-670): Support external wallet imports, wallet imports from CDP Python SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 - Add `networkId` to `WalletData` so that it is saved with the seed data and surfaced via the export function
 - Add ability to import external wallets into CDP via a BIP-39 mnemonic phrase, as a 1-of-1 wallet
 - Add ability to import WalletData files exported by the Python CDP SDK
-- Deprecate `Wallet.loadSeed()` method in favor of `loadSeedFromFile()`
-- Deprecate `Wallet.saveSeed()` method in favor of `saveSeedToFile()`
+- Deprecate `Wallet.loadSeed()` method in favor of `Wallet.loadSeedFromFile()`
+- Deprecate `Wallet.saveSeed()` method in favor of `Wallet.saveSeedToFile()`
 
 ## [0.12.0] - Skipped
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 - Add `networkId` to `WalletData` so that it is saved with the seed data and surfaced via the export function
 - Add ability to import external wallets into CDP via a BIP-39 mnemonic phrase, as a 1-of-1 wallet
 - Add ability to import WalletData files exported by the Python CDP SDK
-- Deprecate `Wallet.loadSeed` method in favor of `loadSeedFromFile`
-- Deprecate `Wallet.saveSeed` method in favor of `saveSeedToFile`
+- Deprecate `Wallet.loadSeed()` method in favor of `loadSeedFromFile()`
+- Deprecate `Wallet.saveSeed()` method in favor of `saveSeedToFile()`
 
 ## [0.12.0] - Skipped
 

--- a/README.md
+++ b/README.md
@@ -201,13 +201,13 @@ For convenience during testing, we provide a `saveSeed` method that stores the w
 
 ```typescript
 const seedFilePath = "";
-wallet.saveSeed(seedFilePath);
+wallet.saveSeedToFile(seedFilePath);
 ```
 
 To encrypt the saved data, set encrypt to true. Note that your CDP API key also serves as the encryption key for the data persisted locally. To re-instantiate wallets with encrypted data, ensure that your SDK is configured with the same API key when invoking `saveSeed` and `loadSeed`.
 
 ```typescript
-wallet.saveSeed(seedFilePath, true);
+wallet.saveSeedToFile(seedFilePath, true);
 ```
 
 The below code demonstrates how to re-instantiate a Wallet from the data export.
@@ -221,7 +221,7 @@ To import Wallets that were persisted to your local file system using `saveSeed`
 
 ```typescript
 const userWallet = await Wallet.fetch(wallet.getId());
-await userWallet.loadSeed(seedFilePath);
+await userWallet.loadSeedFromFile(seedFilePath);
 ```
 
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   maxWorkers: 1,
   coverageThreshold: {
     "./src/coinbase/**": {
-      branches: 75,
+      branches: 74,
       functions: 85,
       statements: 85,
       lines: 85,

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   maxWorkers: 1,
   coverageThreshold: {
     "./src/coinbase/**": {
-      branches: 74,
+      branches: 75,
       functions: 85,
       statements: 85,
       lines: 85,

--- a/quickstart-template/bridge-usdc.js
+++ b/quickstart-template/bridge-usdc.js
@@ -141,7 +141,7 @@ async function getTransactionReceipt(txHash) {
 async function fetchWalletAndLoadSeed(walletId, seedFilePath) {
     try {
         const wallet = await Wallet.fetch(walletId);
-        await wallet.loadSeed(seedFilePath);
+        await wallet.loadSeedFromFile(seedFilePath);
 
         console.log(`Successfully loaded funded wallet: `, wallet.getId());
         return wallet;

--- a/quickstart-template/discord_tutorial/webhook-transfer.js
+++ b/quickstart-template/discord_tutorial/webhook-transfer.js
@@ -26,7 +26,7 @@ const webhookNotificationUri = process.env.WEBHOOK_NOTIFICATION_URL;
   // Create Wallet
   else {
     myWallet = await Wallet.create();
-    const saveSeed = myWallet.saveSeed(seedPath);
+    const saveSeed = myWallet.saveSeedToFile(seedPath);
     console.log("✅ Seed saved: ", saveSeed);
   }
 

--- a/quickstart-template/register-basename.js
+++ b/quickstart-template/register-basename.js
@@ -133,7 +133,7 @@ async function registerBaseName(wallet, registerArgs) {
 async function fetchWalletAndLoadSeed(walletId, seedFilePath) {
   try {
     const wallet = await Wallet.fetch(walletId);
-    await wallet.loadSeed(seedFilePath);
+    await wallet.loadSeedFromFile(seedFilePath);
 
     console.log(`Successfully loaded funded wallet: `, wallet);
     return wallet;

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -226,7 +226,7 @@ export type WalletAPIClient = {
    * List wallets belonging to the user.
    *
    * @param limit - A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
-   * @param page - A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+   * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
    * @param options - Override http request option.
    * @throws {APIError} If the request fails.
    * @throws {RequiredError} If the required parameter is not provided.
@@ -358,7 +358,7 @@ export type AddressAPIClient = {
    * @param walletId - The ID of the wallet the address belongs to.
    * @param addressId - The onchain address of the address to sign the payload with.
    * @param limit - A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
-   * @param page - A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+   * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
    * @param options - Axios request options.
    * @throws {APIError} If the request fails.
    */
@@ -380,7 +380,7 @@ export type ExternalAddressAPIClient = {
    *
    * @param networkId - The ID of the blockchain network
    * @param addressId - The ID of the address to fetch the balance for
-   * @param page - A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+   * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
    * @param options - Override http request option.
    * @throws {APIError} If the request fails.
    */
@@ -812,13 +812,42 @@ export enum FundOperationStatus {
 }
 
 /**
- * The Wallet Data type definition.
+ * The Wallet Data type definition in camelCase format.
  * The data required to recreate a Wallet.
  */
 export type WalletData = {
   walletId: string;
   seed: string;
 };
+
+/**
+ * The Wallet Data type definition in snake_case format.
+ * The data required to recreate a Wallet.
+ */
+export type WalletDataSnake = {
+  wallet_id: string;
+  seed: string;
+};
+
+/**
+ * Type guard to check if data matches the snake_case WalletDataSnake format.
+ *
+ * @param data - The data to check
+ * @returns True if data matches WalletDataSnake format
+ */
+export function isWalletDataSnake(data: unknown): data is WalletDataSnake {
+  return typeof data === "object" && data !== null && "wallet_id" in data && "seed" in data;
+}
+
+/**
+ * Type guard to check if data matches the camelCase WalletData format.
+ *
+ * @param data - The data to check
+ * @returns True if data matches WalletData format
+ */
+export function isWalletData(data: unknown): data is WalletData {
+  return typeof data === "object" && data !== null && "walletId" in data && "seed" in data;
+}
 
 /**
  * The Seed Data type definition.
@@ -852,6 +881,7 @@ export enum ServerSignerStatus {
  * Options for creating a Wallet.
  */
 export type WalletCreateOptions = {
+  seed?: string;
   networkId?: string;
   timeoutSeconds?: number;
   intervalSeconds?: number;
@@ -1145,7 +1175,7 @@ export interface WebhookApiClient {
    *
    * @summary List webhooks
    * @param {number} [limit] - A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
-   * @param {string} [page] - A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+   * @param {string} [page] - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
    * @param {*} [options] - Override http request option.
    * @throws {RequiredError}
    */
@@ -1180,7 +1210,7 @@ export interface BalanceHistoryApiClient {
    * @param addressId - The ID of the address to fetch the historical balance for.
    * @param assetId - The symbol of the asset to fetch the historical balance for.
    * @param limit - A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
-   * @param page - A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+   * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
    * @param options - Override http request option.
    * @throws {RequiredError}
    */
@@ -1202,7 +1232,7 @@ export interface TransactionHistoryApiClient {
    * @param networkId - The ID of the blockchain network
    * @param addressId - The ID of the address to fetch transactions for.
    * @param limit - A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
-   * @param page - A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+   * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
    * @param options - Override http request option.
    * @throws {RequiredError}
    */
@@ -1444,7 +1474,7 @@ export interface FundOperationApiClient {
    * @param walletId - The ID of the wallet the address belongs to.
    * @param addressId - The ID of the address to list fund operations for.
    * @param limit - A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
-   * @param page - A cursor for pagination across multiple pages of results. Don\&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+   * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
    * @param options - Axios request options
    * @throws {APIError} If the request fails
    */

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -812,41 +812,70 @@ export enum FundOperationStatus {
 }
 
 /**
- * The Wallet Data type definition in camelCase format.
- * The data required to recreate a Wallet.
+ * Interface representing wallet data, with support for both camelCase and snake_case
+ * property names for compatibility with older versions of the Python SDK.
  */
-export type WalletData = {
-  walletId: string;
-  seed: string;
-};
+export interface WalletData {
+  /**
+   * The CDP wallet ID in either camelCase or snake_case format, but not both.
+   */
+  walletId?: string;
+  wallet_id?: string;
 
-/**
- * The Wallet Data type definition in snake_case format.
- * The data required to recreate a Wallet.
- */
-export type WalletDataSnake = {
-  wallet_id: string;
+  /**
+   * The wallet seed
+   */
   seed: string;
-};
-
-/**
- * Type guard to check if data matches the snake_case WalletDataSnake format.
- *
- * @param data - The data to check
- * @returns True if data matches WalletDataSnake format
- */
-export function isWalletDataSnake(data: unknown): data is WalletDataSnake {
-  return typeof data === "object" && data !== null && "wallet_id" in data && "seed" in data;
 }
 
 /**
- * Type guard to check if data matches the camelCase WalletData format.
+ * Type guard to check if data matches the appropriate WalletData format.
+ * WalletData must have exactly one of (walletId or wallet_id), and a seed.
  *
  * @param data - The data to check
- * @returns True if data matches WalletData format
+ * @returns True if data matches the appropriate WalletData format
  */
 export function isWalletData(data: unknown): data is WalletData {
-  return typeof data === "object" && data !== null && "walletId" in data && "seed" in data;
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+
+  const { walletId, wallet_id, seed } = data as WalletData;
+
+  // Check that exactly one of walletId or wallet_id is present (but not both)
+  const hasWalletId = typeof walletId === "string";
+  const hasWalletSnakeId = typeof wallet_id === "string";
+  if (!(hasWalletId !== hasWalletSnakeId)) {
+    return false;
+  }
+  const hasSeed = typeof seed === "string";
+
+  return hasSeed;
+}
+
+/**
+ * Interface representing a BIP-39 mnemonic seed phrase.
+ */
+export interface MnemonicSeedPhrase {
+  /**
+   * The BIP-39 mnemonic seed phrase (12, 15, 18, 21, or 24 words)
+   */
+  mnemonicPhrase: string;
+}
+
+/**
+ * Type guard to check if data matches the MnemonicSeedPhrase format.
+ *
+ * @param data - The data to check
+ * @returns True if data matches the MnemonicSeedPhrase format
+ */
+export function isMnemonicSeedPhrase(data: unknown): data is MnemonicSeedPhrase {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+
+  const { mnemonicPhrase } = data as MnemonicSeedPhrase;
+  return typeof mnemonicPhrase === "string";
 }
 
 /**

--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -826,12 +826,20 @@ export interface WalletData {
    * The wallet seed
    */
   seed: string;
-  networkId: string;
+
+  /**
+   * The network ID in either camelCase or snake_case format, but not both.
+   */
+  networkId?: string;
+  network_id?: string;
 }
 
 /**
  * Type guard to check if data matches the appropriate WalletData format.
- * WalletData must have exactly one of (walletId or wallet_id), and a seed.
+ * WalletData must have:
+ * - exactly one of (walletId or wallet_id)
+ * - at most one of (networkId or network_id)
+ * - a seed
  *
  * @param data - The data to check
  * @returns True if data matches the appropriate WalletData format
@@ -841,7 +849,7 @@ export function isWalletData(data: unknown): data is WalletData {
     return false;
   }
 
-  const { walletId, wallet_id, seed } = data as WalletData;
+  const { walletId, wallet_id, networkId, network_id, seed } = data as WalletData;
 
   // Check that exactly one of walletId or wallet_id is present (but not both)
   const hasWalletId = typeof walletId === "string";
@@ -849,9 +857,16 @@ export function isWalletData(data: unknown): data is WalletData {
   if (!(hasWalletId !== hasWalletSnakeId)) {
     return false;
   }
-  const hasSeed = typeof seed === "string";
 
-  return hasSeed;
+  // Check that at most one of networkId or network_id is present (but not both)
+  const hasNetworkId = typeof networkId === "string";
+  const hasNetworkSnakeId = typeof network_id === "string";
+  if (hasNetworkId && hasNetworkSnakeId) {
+    return false;
+  }
+
+  // Check that seed is present and is a string
+  return typeof seed === "string";
 }
 
 /**

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -285,7 +285,7 @@ export class Wallet {
    * @returns The Wallet's data.
    * @throws {APIError} - If the request fails.
    */
-  public export(): Required<WalletData> {
+  public export(): WalletData {
     if (!this.seed) {
       throw new Error("Cannot export Wallet without loaded seed");
     }

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -141,7 +141,7 @@ export class Wallet {
    * @param mnemonicSeedPhrase - The BIP-39 mnemonic seed phrase (12, 15, 18, 21, or 24 words).
    * @returns The imported Wallet.
    * @throws {ArgumentError} If the seed phrase is not provided or invalid.
-   * @throws {ArgumentError} If the seed phrase is not 12 or 24 words.
+   * @throws {ArgumentError} If the seed phrase is not 12, 15, 18, 21, or 24 words.
    * @throws {APIError} If the request fails.
    */
   public static async importFromMnemonicSeedPhrase(mnemonicSeedPhrase: string): Promise<Wallet> {

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -717,7 +717,7 @@ export class Wallet {
       encrypted: encrypt,
       authTag: authTag,
       iv: iv,
-      networkId: data.networkId,
+      networkId: data.networkId!,
     };
 
     fs.writeFileSync(filePath, JSON.stringify(existingSeedsInStore, null, 2), "utf8");

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -126,6 +126,7 @@ describe("Coinbase SDK E2E Test", () => {
       result = await (await unhydratedWallet.getDefaultAddress()).listTransactions({ limit: 1 });
       if (result?.data.length > 0) break;
       // Wait 2 seconds between attempts
+      console.log(`Waiting for transaction to be processed... (${i + 1} attempts)`);
       await new Promise(resolve => setTimeout(resolve, 2000));
     }
     expect(result?.data.length).toBeGreaterThan(0);

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -54,7 +54,7 @@ describe("Coinbase SDK E2E Test", () => {
     const walletId = Object.keys(seedFile)[0];
     const seed = seedFile[walletId].seed;
 
-    const importedWallet = await Wallet.import({ seed, walletId });
+    const importedWallet = await Wallet.load({ seed, walletId });
     expect(importedWallet).toBeDefined();
     expect(importedWallet.getId()).toBe(walletId);
     console.log(

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -54,13 +54,13 @@ describe("Coinbase SDK E2E Test", () => {
     const walletId = Object.keys(seedFile)[0];
     const seed = seedFile[walletId].seed;
 
-    const importedWallet = await Wallet.load({ seed, walletId });
+    const importedWallet = await Wallet.import({ seed, walletId });
     expect(importedWallet).toBeDefined();
     expect(importedWallet.getId()).toBe(walletId);
     console.log(
       `Imported wallet with ID: ${importedWallet.getId()}, default address: ${importedWallet.getDefaultAddress()}`,
     );
-    await importedWallet.saveSeed("test_seed.json");
+    await importedWallet.saveSeedToFile("test_seed.json");
 
     try {
       const transaction = await importedWallet.faucet();
@@ -84,13 +84,13 @@ describe("Coinbase SDK E2E Test", () => {
     expect(exportedWallet.seed).toBeDefined();
 
     console.log("Saving seed to file...");
-    await wallet.saveSeed("test_seed.json");
+    await wallet.saveSeedToFile("test_seed.json");
     expect(fs.existsSync("test_seed.json")).toBe(true);
     console.log("Saved seed to test_seed.json");
 
     const unhydratedWallet = await Wallet.fetch(walletId);
     expect(unhydratedWallet.canSign()).toBe(false);
-    await unhydratedWallet.loadSeed("test_seed.json");
+    await unhydratedWallet.loadSeedFromFile("test_seed.json");
     expect(unhydratedWallet.canSign()).toBe(true);
     expect(unhydratedWallet.getId()).toBe(walletId);
 
@@ -133,7 +133,7 @@ describe("Coinbase SDK E2E Test", () => {
     fs.unlinkSync("test_seed.json");
 
     expect(exportedWallet.seed.length).toBe(64);
-    expect(savedSeed[exportedWallet.walletId]).toEqual({
+    expect(savedSeed[exportedWallet.walletId!]).toEqual({
       seed: exportedWallet.seed,
       encrypted: false,
       authTag: "",

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -120,11 +120,15 @@ describe("Coinbase SDK E2E Test", () => {
     console.log(`Second address balances: ${secondBalance}`);
 
     console.log("Fetching address transactions...");
-    const result = await (
-      await unhydratedWallet.getDefaultAddress()
-    ).listTransactions({ limit: 1 });
+    let result;
+    for (let i = 0; i < 5; i++) {
+      // Try up to 5 times
+      result = await (await unhydratedWallet.getDefaultAddress()).listTransactions({ limit: 1 });
+      if (result?.data.length > 0) break;
+      // Wait 2 seconds between attempts
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
     expect(result?.data.length).toBeGreaterThan(0);
-    console.log(`Fetched transactions: ${result?.data[0].toString()}`);
 
     console.log("Fetching address historical balances...");
     const balance_result = await (

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -1026,6 +1026,13 @@ describe("Wallet Class", () => {
         "Wallet ID must be provided",
       );
     });
+    it("should throw an error when seed is not provided", async () => {
+      const walletData = seedWallet.export();
+      walletData.seed = "";
+      await expect(async () => await Wallet.load(walletData)).rejects.toThrow(
+        "Seed must be provided",
+      );
+    });
     it("should throw an error when wallet data format is invalid", async () => {
       const invalidWalletData = {
         foo: "bar",


### PR DESCRIPTION
### What changed? Why?

- Support external 1-of-1 wallet import via BIP-39 mnemonic phrases (12, 15, 18, 21, or 24 words)
- Support import of wallet data exported from CDP Python SDK
- Renamed saveSeed() to saveSeedtoFile(), and deprecated the former
- Renamed loadSeed() to loadSeedFromFile(), and deprecated the former
- Added retry mechanism to address.listTransactions() E2E test for better resiliency

### Testing

Tested via:
- Import of 12, 15, 18, 21, and 24-word mnemonic seed phrases
- Export of wallets generated via mnemonic seed phrases
- Import of wallets generated via mnemonic seed phrases, that were then exported 
- Successfully imported wallet exported from CDP Python SDK `v0.12.0`
- Successfully imported wallet exported from CDP NodeJS SDK `v0.11.0`

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
