### PR TITLE
chore: make network_id in WalletData optional

### DIFF
--- a/src/coinbase/types.ts
+++ b/src/coinbase/types.ts
@@ -818,7 +818,7 @@ export enum FundOperationStatus {
 export type WalletData = {
   walletId: string;
   seed: string;
-  networkId: string;
+  networkId?: string;
 };
 
 /**

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -217,7 +217,7 @@ export class Wallet {
    * @returns The Wallet's data.
    * @throws {APIError} - If the request fails.
    */
-  public export(): WalletData {
+  public export(): Required<WalletData> {
     if (!this.seed) {
       throw new Error("Cannot export Wallet without loaded seed");
     }


### PR DESCRIPTION
### What changed? Why?
The [original PR that added `networkId`](https://github.com/coinbase/coinbase-sdk-nodejs/pull/343) should have added it as an optional property to maintain backwards compatibility. Since `WalletData` is used as the input type to `import`, adding a required `networkId` prop is inadvertently a breaking change. By marking `networkId` as optional, devs who have previously saved wallets who upgrade to v0.13+ will still be able to use `import` without making any code changes.