### PR TITLE
chore: bump version to v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Coinbase Node.js SDK Changelog
 
-## Unreleased
+## [0.13.0] - 2024-12-19
+
+### Added
 - Add support for registering, updating, and listing smart contracts that are
   deployed external to CDP.
 - Add support for fetching address reputation
@@ -8,6 +10,8 @@
 - Add `networkId` to `WalletData` so that it is saved with the seed data and surfaced via the export function
 - Add ability to import external wallets into CDP via a BIP-39 mnemonic phrase, as a 1-of-1 wallet
 - Add ability to import WalletData files exported by the Python CDP SDK
+
+### Deprecated
 - Deprecate `Wallet.loadSeed()` method in favor of `Wallet.loadSeedFromFile()`
 - Deprecate `Wallet.saveSeed()` method in favor of `Wallet.saveSeedToFile()`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coinbase/coinbase-sdk",
-  "version": "0.11.3",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coinbase/coinbase-sdk",
-      "version": "0.11.3",
+      "version": "0.13.0",
       "license": "ISC",
       "dependencies": {
         "@scure/bip32": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "ISC",
   "description": "Coinbase Platform SDK",
   "repository": "https://github.com/coinbase/coinbase-sdk-nodejs",
-  "version": "0.11.3",
+  "version": "0.13.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/quickstart-template/package.json
+++ b/quickstart-template/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@solana/web3.js": "^2.0.0-rc.1",
     "bs58": "^6.0.0",
-    "@coinbase/coinbase-sdk": "^0.11.2",
+    "@coinbase/coinbase-sdk": "^0.13.0",
     "csv-parse": "^5.5.6",
     "csv-writer": "^1.6.0",
     "viem": "^2.21.6"


### PR DESCRIPTION
### What changed? Why?
Bump version to v0.13.0
