### PR TITLE
chore: update transfer wait timeout to 40 seconds

### DIFF
--- a/src/coinbase/transfer.ts
+++ b/src/coinbase/transfer.ts
@@ -239,7 +239,7 @@ export class Transfer {
    * @returns The Transfer object in a terminal state.
    * @throws {Error} if the Transfer times out.
    */
-  public async wait({ intervalSeconds = 0.2, timeoutSeconds = 10 } = {}): Promise<Transfer> {
+  public async wait({ intervalSeconds = 0.2, timeoutSeconds = 40 } = {}): Promise<Transfer> {
     const startTime = Date.now();
 
     while (Date.now() - startTime < timeoutSeconds * 1000) {


### PR DESCRIPTION
### What changed? Why?

We're seeing occasional timeouts, so we are increasing the default while we explore solutions

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
