### PR TITLE
chore: Allow Specified Network ID on Mnemonic Phrase Wallet Import

### DIFF
--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -143,12 +143,16 @@ export class Wallet {
    *     Allows for the loading of an existing CDP wallet into CDP.
    *   - If MnemonicSeedPhrase: Must contain a valid BIP-39 mnemonic phrase (12, 15, 18, 21, or 24 words).
    *     Allows for the import of an external wallet into CDP as a 1-of-1 wallet.
+   * @param networkId - the ID of the blockchain network. Defaults to 'base-sepolia'.
    * @returns A Promise that resolves to the loaded Wallet instance
    * @throws {ArgumentError} If the data format is invalid.
    * @throws {ArgumentError} If the seed is not provided.
    * @throws {ArgumentError} If the mnemonic seed phrase is invalid.
    */
-  public static async import(data: WalletData | MnemonicSeedPhrase): Promise<Wallet> {
+  public static async import(
+    data: WalletData | MnemonicSeedPhrase,
+    networkId: string = Coinbase.networks.BaseSepolia,
+  ): Promise<Wallet> {
     // Check if data is a mnemonic seed phrase object
     if (isMnemonicSeedPhrase(data)) {
       // Handle mnemonic seed phrase object import
@@ -168,7 +172,7 @@ export class Wallet {
       // Create wallet using the provided seed
       const wallet = await Wallet.createWithSeed({
         seed: seed,
-        networkId: Coinbase.networks.BaseSepolia,
+        networkId,
       });
 
       // Ensure the wallet is created

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -1101,6 +1101,18 @@ describe("Wallet Class", () => {
       expect(Coinbase.apiClients.address!.listAddresses).toHaveBeenCalledTimes(1);
     });
 
+    it("successfully imports a wallet from a valid 24-word mnemonic on base-mainnet", async () => {
+      const wallet = await Wallet.import(
+        { mnemonicPhrase: validMnemonic },
+        Coinbase.networks.BaseMainnet,
+      );
+      expect(wallet).toBeInstanceOf(Wallet);
+      expect(wallet.getNetworkId()).toEqual(Coinbase.networks.BaseMainnet);
+      expect(Coinbase.apiClients.wallet!.createWallet).toHaveBeenCalledTimes(1);
+      expect(Coinbase.apiClients.address!.createAddress).toHaveBeenCalledTimes(1);
+      expect(Coinbase.apiClients.address!.listAddresses).toHaveBeenCalledTimes(1);
+    });
+
     it("throws an error when mnemonic is empty", async () => {
       await expect(Wallet.import({ mnemonicPhrase: "" })).rejects.toThrow(
         "BIP-39 mnemonic seed phrase must be provided",


### PR DESCRIPTION
### What changed? Why?
- Hot Fix Wallet.import_wallet(...) method to allow for specifying `network_id` optionally defaulting to `base-sepolia`
- Note: This is not a breaking change because the input arg is optional

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
