### PR TITLE
chore: added USDC gasless transfer e2e test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Add E2E test for gasless transfers `Wallet.createTransfer({..., gasless: true})`
+
 ### Fixed
 - Fixed a bug where non-checksummed asset IDs were throwing an error.
 

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -165,10 +165,13 @@ describe("Coinbase SDK E2E Test", () => {
     
     // Create destination wallet
     const destinationWallet = await Wallet.create();
+
+    // Initialize transfer amount
+    const transferAmount = 0.000001;
     
-    console.log("Making gasless transfer of 0.000001 USDC...");
+    console.log(`Making gasless transfer of ${transferAmount} USDC...`);
     const transfer = await sourceWallet.createTransfer({
-      amount: 0.000001,
+      amount: transferAmount,
       assetId: Coinbase.assets.Usdc,
       destination: destinationWallet,
       gasless: true,
@@ -184,7 +187,7 @@ describe("Coinbase SDK E2E Test", () => {
     const sourceBalance = await sourceWallet.listBalances();
     const destBalance = await destinationWallet.listBalances();
     expect(sourceBalance.get(Coinbase.assets.Usdc)).not.toEqual("0");
-    expect(destBalance.get(Coinbase.assets.Usdc)?.toString()).toEqual("0.000001");
+    expect(destBalance.get(Coinbase.assets.Usdc)?.toString()).toEqual(`${transferAmount}`);
     console.log(`Source balance: ${sourceBalance}`);
     console.log(`Destination balance: ${destBalance}`);
   }, 200000);

--- a/src/tests/e2e.ts
+++ b/src/tests/e2e.ts
@@ -150,6 +150,44 @@ describe("Coinbase SDK E2E Test", () => {
       networkId: exportedWallet.networkId,
     });
   }, 60000);
+
+  it("should be able to make gasless transfers", async () => {
+    // Import wallet with balance
+    const seedFile = JSON.parse(process.env.WALLET_DATA || "");
+    const walletId = Object.keys(seedFile)[0];
+    const seed = seedFile[walletId].seed;
+
+    const sourceWallet = await Wallet.import({
+      seed,
+      walletId,
+      networkId: Coinbase.networks.BaseSepolia,
+    });
+    
+    // Create destination wallet
+    const destinationWallet = await Wallet.create();
+    
+    console.log("Making gasless transfer of 0.000001 USDC...");
+    const transfer = await sourceWallet.createTransfer({
+      amount: 0.000001,
+      assetId: Coinbase.assets.Usdc,
+      destination: destinationWallet,
+      gasless: true,
+    });
+
+    await transfer.wait();
+
+    expect(transfer.toString()).toBeDefined();
+    expect(await transfer.getStatus()).toBe(TransferStatus.COMPLETE);
+    console.log(`Completed gasless transfer from ${sourceWallet} to ${destinationWallet}`);
+
+    // Verify balances
+    const sourceBalance = await sourceWallet.listBalances();
+    const destBalance = await destinationWallet.listBalances();
+    expect(sourceBalance.get(Coinbase.assets.Usdc)).not.toEqual("0");
+    expect(destBalance.get(Coinbase.assets.Usdc)?.toString()).toEqual("0.000001");
+    console.log(`Source balance: ${sourceBalance}`);
+    console.log(`Destination balance: ${destBalance}`);
+  }, 200000);
 });
 
 describe("Coinbase SDK Stake E2E Test", () => {


### PR DESCRIPTION
### What changed? Why?
A Gasless transfer test was added for E2E tests. This test improves coverage for the gasless transfer feature, by ensuring the SDK can make gasless transfers for USDC over Base Sepolia.

#### Qualified Impact
This change will impact the E2E tests, which currently run in our CI/CD pipeline for Github PRs. The wallet data that is used for transferring USDC over Base Sepolia will need to be funded in case in runs out of funds for the test to pass.
