### PR TITLE
feat: expose fee recipient & forwarded fee recipient addresses on validator and pending_claimable_balance on external address

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1720,6 +1720,18 @@ export interface EthereumValidatorMetadata {
      * @memberof EthereumValidatorMetadata
      */
     'effective_balance': Balance;
+    /**
+     * The address for execution layer rewards (MEV & tx fees). If using a reward splitter plan, this is a smart contract  address that splits rewards based on defined commissions and send a portion to the forwarded_fee_recipient_address. 
+     * @type {string}
+     * @memberof EthereumValidatorMetadata
+     */
+    'fee_recipient_address': string;
+    /**
+     * If using a reward splitter plan, this address receives a defined percentage of the total execution layer rewards. 
+     * @type {string}
+     * @memberof EthereumValidatorMetadata
+     */
+    'forwarded_fee_recipient_address'?: string;
 }
 /**
  * The faucet transaction
@@ -3261,6 +3273,12 @@ export interface StakingContextContext {
      * @memberof StakingContextContext
      */
     'unstakeable_balance': Balance;
+    /**
+     * 
+     * @type {Balance}
+     * @memberof StakingContextContext
+     */
+    'pending_claimable_balance': Balance;
     /**
      * 
      * @type {Balance}

--- a/src/coinbase/address.ts
+++ b/src/coinbase/address.ts
@@ -280,6 +280,23 @@ export class Address {
   }
 
   /**
+   * Get the pending claimable balance for the supplied asset.
+   *
+   * @param asset_id - The asset to check claimable balance for.
+   * @param mode - The staking mode. Defaults to DEFAULT.
+   * @param options - Additional options for getting the claimable balance.
+   * @returns The claimable balance.
+   */
+  public async pendingClaimableBalance(
+    asset_id: string,
+    mode: StakeOptionsMode = StakeOptionsMode.DEFAULT,
+    options: { [key: string]: string } = {},
+  ): Promise<Decimal> {
+    const balances = await this.getStakingBalances(asset_id, mode, options);
+    return balances.pendingClaimableBalance;
+  }
+
+  /**
    * Requests faucet funds for the address.
    * Only supported on testnet networks.
    *
@@ -456,6 +473,10 @@ export class Address {
       ).amount,
       unstakeableBalance: Balance.fromModelAndAssetId(
         response!.data.context.unstakeable_balance,
+        assetId,
+      ).amount,
+      pendingClaimableBalance: Balance.fromModelAndAssetId(
+        response!.data.context.pending_claimable_balance,
         assetId,
       ).amount,
       claimableBalance: Balance.fromModelAndAssetId(

--- a/src/coinbase/validator.ts
+++ b/src/coinbase/validator.ts
@@ -254,6 +254,25 @@ export class Validator {
   }
 
   /**
+   * Returns the address for execution layer rewards (MEV & tx fees).If using a reward splitter plan, this is a smart contract
+   * address that splits rewards based on defined commissions and send a portion to the forwarded_fee_recipient_address.
+   *
+   * @returns The fee recipient address as a string.
+   */
+  public getFeeRecipientAddress(): string {
+    return this.model.details?.fee_recipient_address || "";
+  }
+
+  /**
+   * If using a reward splitter plan, this address receives a defined percentage of the total execution layer rewards.
+   *
+   * @returns The forwarded fee recipient address as a string.
+   */
+  public getForwardedFeeRecipientAddress(): string {
+    return this.model.details?.forwarded_fee_recipient_address || "";
+  }
+
+  /**
    * Returns the string representation of the Validator.
    *
    * @returns The string representation of the Validator.

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -448,6 +448,23 @@ export class Wallet {
   }
 
   /**
+   * Get the pending claimable balance for the supplied asset.
+   *
+   * @param asset_id - The asset to check pending claimable balance for.
+   * @param mode - The staking mode. Defaults to DEFAULT.
+   * @param options - Additional options for getting the pending claimable balance.
+   * @throws {Error} if the default address is not found.
+   * @returns The pending claimable balance.
+   */
+  public async pendingClaimableBalance(
+    asset_id: string,
+    mode: StakeOptionsMode = StakeOptionsMode.DEFAULT,
+    options: { [key: string]: string } = {},
+  ): Promise<Decimal> {
+    return (await this.getDefaultAddress()).pendingClaimableBalance(asset_id, mode, options);
+  }
+
+  /**
    * Get the claimable balance for the supplied asset.
    *
    * @param asset_id - The asset to check claimable balance for.

--- a/src/tests/stake_test.ts
+++ b/src/tests/stake_test.ts
@@ -5,7 +5,6 @@ import {
   mockReturnValue,
   stakeApiMock,
   VALID_ACTIVE_VALIDATOR_LIST,
-  validatorApiMock,
 } from "./utils";
 import { ValidatorStatus } from "../coinbase/types";
 import { ValidatorStatus as APIValidatorStatus } from "../client/api";

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -627,6 +627,8 @@ export function mockEthereumValidator(
       index: index,
       public_key: public_key,
       withdrawal_address: "0xwithdrawal_address_1",
+      fee_recipient_address: "0xfee_recipient_address_1",
+      forwarded_fee_recipient_address: "0xforwarded_fee_recipient_address_1",
       slashed: false,
       activationEpoch: "10",
       exitEpoch: "10",

--- a/src/tests/validator_test.ts
+++ b/src/tests/validator_test.ts
@@ -29,6 +29,7 @@ describe("Validator", () => {
         slashed: false,
         withdrawableEpoch: "epoch-2",
         withdrawal_address: "withdrawal-address-123",
+        fee_recipient_address: "fee-recipient-address-123",
       },
     };
 
@@ -77,6 +78,14 @@ describe("Validator", () => {
 
   test("getWithdrawalAddress should return the correct withdrawal address", () => {
     expect(validator.getWithdrawalAddress()).toBe("withdrawal-address-123");
+  });
+
+  test("getFeeRecipientAddress should return the correct fee recipient address", () => {
+    expect(validator.getFeeRecipientAddress()).toBe("fee-recipient-address-123");
+  });
+
+  test("getForwardedFeeRecipientAddress should return the correct forwarded fee recipient address", () => {
+    expect(validator.getForwardedFeeRecipientAddress()).toBe("");
   });
 
   test("getEffectiveBalance should return the correct effective balance", () => {

--- a/src/tests/wallet_address_test.ts
+++ b/src/tests/wallet_address_test.ts
@@ -388,6 +388,15 @@ describe("WalletAddress", () => {
             contract_address: "0x",
           },
         },
+        pending_claimable_balance: {
+          amount: "1000000000000000000",
+          asset: {
+            asset_id: Coinbase.assets.Eth,
+            network_id: Coinbase.networks.EthereumHolesky,
+            decimals: 18,
+            contract_address: "0x",
+          },
+        },
         claimable_balance: {
           amount: "1000000000000000000",
           asset: {
@@ -1243,10 +1252,10 @@ describe("WalletAddress", () => {
   });
 
   describe("#invokeContract", () => {
-    let key = ethers.Wallet.createRandom();
+    const key = ethers.Wallet.createRandom();
     let addressModel: AddressModel;
     let walletAddress: WalletAddress;
-    let unsignedPayload = VALID_CONTRACT_INVOCATION_MODEL.transaction.unsigned_payload;
+    const unsignedPayload = VALID_CONTRACT_INVOCATION_MODEL.transaction.unsigned_payload;
     let expectedSignedPayload: string;
 
     beforeAll(() => {
@@ -1334,8 +1343,8 @@ describe("WalletAddress", () => {
 
       describe("when it is successful invoking a payable contract method", () => {
         let contractInvocation;
-        let amount = new Decimal("1000");
-        let balanceResponse = { amount: "5000000", asset: { asset_id: "eth", decimals: 18 } };
+        const amount = new Decimal("1000");
+        const balanceResponse = { amount: "5000000", asset: { asset_id: "eth", decimals: 18 } };
 
         beforeEach(async () => {
           Coinbase.apiClients.contractInvocation!.createContractInvocation = mockReturnValue({
@@ -1421,7 +1430,7 @@ describe("WalletAddress", () => {
       });
 
       describe("when it is fails to invoke a payable contract method", () => {
-        let amount = new Decimal("1000");
+        const amount = new Decimal("1000");
 
         it("throws an error for invalid input", async () => {
           await expect(
@@ -1595,7 +1604,7 @@ describe("WalletAddress", () => {
   });
 
   describe("#deployToken", () => {
-    let key = ethers.Wallet.createRandom();
+    const key = ethers.Wallet.createRandom();
     let addressModel: AddressModel;
     let walletAddress: WalletAddress;
     let expectedSignedPayload: string;
@@ -1891,7 +1900,7 @@ describe("WalletAddress", () => {
   });
 
   describe("#deployNFT", () => {
-    let key = ethers.Wallet.createRandom();
+    const key = ethers.Wallet.createRandom();
     let addressModel: AddressModel;
     let walletAddress: WalletAddress;
     let expectedSignedPayload: string;
@@ -2187,7 +2196,7 @@ describe("WalletAddress", () => {
   });
 
   describe("#deployMultiToken", () => {
-    let key = ethers.Wallet.createRandom();
+    const key = ethers.Wallet.createRandom();
     let addressModel: AddressModel;
     let walletAddress: WalletAddress;
     let expectedSignedPayload: string;
@@ -2463,7 +2472,7 @@ describe("WalletAddress", () => {
   });
 
   describe("#deployContract", () => {
-    let key = ethers.Wallet.createRandom();
+    const key = ethers.Wallet.createRandom();
     let addressModel: AddressModel;
     let walletAddress: WalletAddress;
     let expectedSignedPayload: string;
@@ -2741,10 +2750,10 @@ describe("WalletAddress", () => {
   });
 
   describe("#createPayloadSignature", () => {
-    let key = ethers.Wallet.createRandom();
+    const key = ethers.Wallet.createRandom();
     let addressModel: AddressModel;
     let walletAddress: WalletAddress;
-    let unsignedPayload = VALID_PAYLOAD_SIGNATURE_MODEL.unsigned_payload;
+    const unsignedPayload = VALID_PAYLOAD_SIGNATURE_MODEL.unsigned_payload;
     let signature: string;
 
     beforeAll(() => {
@@ -2858,10 +2867,10 @@ describe("WalletAddress", () => {
   });
 
   describe("#getPayloadSignature", () => {
-    let key = ethers.Wallet.createRandom();
+    const key = ethers.Wallet.createRandom();
     let addressModel: AddressModel;
     let walletAddress: WalletAddress;
-    let payloadSignatureId = VALID_PAYLOAD_SIGNATURE_MODEL.payload_signature_id;
+    const payloadSignatureId = VALID_PAYLOAD_SIGNATURE_MODEL.payload_signature_id;
 
     beforeAll(() => {
       Coinbase.apiClients.address = addressesApiMock;
@@ -2909,7 +2918,7 @@ describe("WalletAddress", () => {
   });
 
   describe("#listPayloadSignatures", () => {
-    let key = ethers.Wallet.createRandom();
+    const key = ethers.Wallet.createRandom();
     let addressModel: AddressModel;
     let walletAddress: WalletAddress;
 

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -165,6 +165,15 @@ describe("Wallet Class", () => {
             contract_address: "0x",
           },
         },
+        pending_claimable_balance: {
+          amount: "1000000000000000000",
+          asset: {
+            asset_id: Coinbase.assets.Eth,
+            network_id: Coinbase.networks.EthereumHolesky,
+            decimals: 18,
+            contract_address: "0x",
+          },
+        },
         claimable_balance: {
           amount: "1000000000000000000",
           asset: {
@@ -573,7 +582,7 @@ describe("Wallet Class", () => {
 
   describe("#invokeContract", () => {
     let expectedInvocation;
-    let options = {
+    const options = {
       abi: MINT_NFT_ABI,
       args: MINT_NFT_ARGS,
       method: VALID_SIGNED_CONTRACT_INVOCATION_MODEL.method,
@@ -631,7 +640,7 @@ describe("Wallet Class", () => {
 
   describe("#deployToken", () => {
     let expectedSmartContract;
-    let options = {
+    const options = {
       name: ERC20_NAME,
       symbol: ERC20_SYMBOL,
       totalSupply: ERC20_TOTAL_SUPPLY,
@@ -658,7 +667,7 @@ describe("Wallet Class", () => {
 
   describe("#deployNFT", () => {
     let expectedSmartContract;
-    let options = {
+    const options = {
       name: ERC721_NAME,
       symbol: ERC721_SYMBOL,
       baseURI: ERC721_BASE_URI,
@@ -685,7 +694,7 @@ describe("Wallet Class", () => {
 
   describe("#deployMultiToken", () => {
     let expectedSmartContract;
-    let options = {
+    const options = {
       uri: "https://example.com/metadata",
     };
 
@@ -710,7 +719,7 @@ describe("Wallet Class", () => {
 
   describe("#deployContract", () => {
     let expectedSmartContract;
-    let options = {
+    const options = {
       solidityVersion: "0.8.0",
       solidityInputJson: "{}",
       contractName: "TestContract",
@@ -737,8 +746,8 @@ describe("Wallet Class", () => {
   });
 
   describe("#createPayloadSignature", () => {
-    let unsignedPayload = VALID_SIGNED_PAYLOAD_SIGNATURE_MODEL.unsigned_payload;
-    let signature =
+    const unsignedPayload = VALID_SIGNED_PAYLOAD_SIGNATURE_MODEL.unsigned_payload;
+    const signature =
       "0xa4e14b28d86dfd7bae739d724ba2ffb13b4458d040930b805eea0a4bc2f5251e7901110677d1ef2ec23ef810c755d0bc72cc6472a4cfb3c53ef242c6ba9fa60a1b";
 
     beforeAll(() => {


### PR DESCRIPTION
### What changed? Why?

This PR helps expose some more staking related details:

1. `fee recipient_address` and `forwarded_fee_recipient_address` on validator
2. `pending_claimable_balance` on external address via the staking context api


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
