### PR TITLE
fix: wallet import should not fail when addresses are out of order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Coinbase Node.js SDK Changelog
 
+## [0.18.1] - 2025-02-13
+
+### Fixed
+- Fixed a bug where import_wallet would fail if the address list was not being sorted by index.
+
 ## [0.18.0] - 2025-02-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coinbase/coinbase-sdk",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coinbase/coinbase-sdk",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "ISC",
       "dependencies": {
         "@scure/bip32": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "ISC",
   "description": "Coinbase Platform SDK",
   "repository": "https://github.com/coinbase/coinbase-sdk-nodejs",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/quickstart-template/package.json
+++ b/quickstart-template/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@solana/web3.js": "^2.0.0-rc.1",
     "bs58": "^6.0.0",
-    "@coinbase/coinbase-sdk": "^0.18.0",
+    "@coinbase/coinbase-sdk": "^0.18.1",
     "csv-parse": "^5.5.6",
     "csv-writer": "^1.6.0",
     "viem": "^2.21.6"

--- a/src/coinbase/wallet.ts
+++ b/src/coinbase/wallet.ts
@@ -390,8 +390,8 @@ export class Wallet {
       Wallet.MAX_ADDRESSES,
     );
 
-    const addresses = response.data.data.map((address, index) => {
-      return this.buildWalletAddress(address, index);
+    const addresses = response.data.data.map(address => {
+      return this.buildWalletAddress(address, address.index);
     });
     this.addresses = addresses;
     return addresses;

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -38,6 +38,7 @@ import { Coinbase } from "../coinbase/coinbase";
 import { convertStringToHex, registerAxiosInterceptors } from "../coinbase/utils";
 import { HDKey } from "@scure/bip32";
 import { Asset } from "../coinbase/asset";
+import { Wallet } from "../coinbase/wallet";
 
 export const mockFn = (...args) => jest.fn(...args) as any;
 export const mockReturnValue = data => jest.fn().mockResolvedValue({ data });
@@ -56,6 +57,7 @@ export const mockListAddress = (seed: string, count = 1) => {
       network_id: Coinbase.networks.BaseSepolia,
       public_key: wallet1PrivateKey,
       wallet_id: randomUUID(),
+      index: i,
     };
   });
 
@@ -114,6 +116,36 @@ export const newAddressModel = (
     wallet_id: walletId,
     index,
   };
+};
+
+export const newAddressModelsFromWallet = async (
+  walletId: string,
+  seed: string,
+  network_id: string = Coinbase.networks.BaseSepolia,
+): Promise<AddressModel[]> => {
+  // create a new wallet with master seed
+  const wallet = HDKey.fromMasterSeed(Buffer.from(seed, "hex"));
+  const address1 = getAddressFromHDKey(wallet.derive("m/44'/60'/0'/0/0"));
+  const address2 = getAddressFromHDKey(wallet.derive("m/44'/60'/0'/0/1"));
+  const publicKey1 = convertStringToHex(wallet.derive("m/44'/60'/0'/0/0").publicKey!);
+  const publicKey2 = convertStringToHex(wallet.derive("m/44'/60'/0'/0/1").publicKey!);
+  
+  return [
+    {
+      address_id: address1,
+      network_id: network_id,
+      public_key: publicKey1,
+      wallet_id: walletId,
+      index: 0,
+    },
+    {
+      address_id: address2,
+      network_id: network_id,
+      public_key: publicKey2,
+      wallet_id: walletId,
+      index: 1,
+    }
+  ];
 };
 
 export const VALID_ADDRESS_MODEL = newAddressModel(randomUUID());


### PR DESCRIPTION
### What changed? Why?
When ListAddress API returns addresses not sorted by addressIndex, wallet.import() method does not handle the address derivation correctly. This PR fixes the behavior

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
