### PR TITLE
Improve error message when SDK is used and not initialized

### DIFF
--- a/src/coinbase/coinbase.ts
+++ b/src/coinbase/coinbase.ts
@@ -25,7 +25,11 @@ import {
 import { BASE_PATH } from "./../client/base";
 import { Configuration } from "./../client/configuration";
 import { CoinbaseAuthenticator } from "./authenticator";
-import { InvalidAPIKeyFormatError, InvalidConfigurationError } from "./errors";
+import {
+  InvalidAPIKeyFormatError,
+  InvalidConfigurationError,
+  UninitializedSDKError,
+} from "./errors";
 import { ApiClients, CoinbaseConfigureFromJsonOptions, CoinbaseOptions } from "./types";
 import { logApiResponse, registerAxiosInterceptors } from "./utils";
 import * as os from "os";
@@ -63,7 +67,14 @@ export class Coinbase {
     Cbbtc: "cbbtc",
   };
 
-  static apiClients: ApiClients = {};
+  static apiClients: ApiClients = new Proxy({} as ApiClients, {
+    get(target, prop) {
+      if (!Reflect.has(target, prop)) {
+        throw new UninitializedSDKError();
+      }
+      return Reflect.get(target, prop);
+    },
+  });
 
   /**
    * The CDP API key Private Key.

--- a/src/coinbase/errors.ts
+++ b/src/coinbase/errors.ts
@@ -133,3 +133,27 @@ export class AlreadySignedError extends Error {
     }
   }
 }
+
+/**
+ * UninitializedSDKError is thrown when the Coinbase instance is not initialized.
+ */
+export class UninitializedSDKError extends Error {
+  static DEFAULT_MESSAGE =
+    "Coinbase SDK has not been initialized. Please initialize by calling either:\n\n" +
+    "- Coinbase.configure({apiKeyName: '...', privateKey: '...'})\n" +
+    "- Coinbase.configureFromJson({filePath: '/path/to/api_keys.json'})\n\n" +
+    "If needed, register for API keys at https://portal.cdp.coinbase.com/ or view the docs at https://docs.cdp.coinbase.com/wallet-api/docs/welcome";
+
+  /**
+   * Initializes a new UninitializedSDKError instance.
+   *
+   * @param message - The error message.
+   */
+  constructor(message: string = UninitializedSDKError.DEFAULT_MESSAGE) {
+    super(message);
+    this.name = "UninitializedSDKError";
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, UninitializedSDKError);
+    }
+  }
+}

--- a/src/tests/authenticator_test.ts
+++ b/src/tests/authenticator_test.ts
@@ -55,13 +55,19 @@ describe("Authenticator tests", () => {
   });
 
   describe("when a source version is provided", () => {
-    beforeAll(() => { sourceVersion = "1.0.0"; });
-    afterAll(() => { sourceVersion = undefined; });
+    beforeAll(() => {
+      sourceVersion = "1.0.0";
+    });
+    afterAll(() => {
+      sourceVersion = undefined;
+    });
 
     it("includes the source version in the correlation context", async () => {
       const config = await authenticator.authenticateRequest(VALID_CONFIG, true);
       const correlationContext = config.headers["Correlation-Context"] as string;
-      expect(correlationContext).toContain("sdk_version=0.20.0,sdk_language=typescript,source=mockSource");
+      expect(correlationContext).toContain(
+        "sdk_version=0.20.0,sdk_language=typescript,source=mockSource",
+      );
     });
   });
 
@@ -81,9 +87,9 @@ describe("Authenticator tests", () => {
     beforeEach(() => {
       instance = new CoinbaseAuthenticator(apiKey, privateKey, source);
       // Override private methods using a type cast.
-      (instance as any).extractPemKey = jest.fn().mockReturnValue(
-        "-----BEGIN EC PRIVATE KEY-----\nMOCK_KEY\n-----END EC PRIVATE KEY-----"
-      );
+      (instance as any).extractPemKey = jest
+        .fn()
+        .mockReturnValue("-----BEGIN EC PRIVATE KEY-----\nMOCK_KEY\n-----END EC PRIVATE KEY-----");
       (instance as any).nonce = jest.fn().mockReturnValue("mockNonce");
     });
 
@@ -92,27 +98,27 @@ describe("Authenticator tests", () => {
       const invalidInstance = new CoinbaseAuthenticator(
         apiKey,
         "-----BEGIN EC PRIVATE KEY-----\nINVALID\n-----END EC PRIVATE KEY-----",
-        source
+        source,
       );
       await expect(invalidInstance.buildJWT("https://example.com")).rejects.toThrow(
-        InvalidAPIKeyFormatError
+        InvalidAPIKeyFormatError,
       );
       await expect(invalidInstance.buildJWT("https://example.com")).rejects.toThrow(
-        "Could not convert the EC private key to PKCS8 format"
+        "Could not convert the EC private key to PKCS8 format",
       );
     });
 
     test("should throw error if key import fails", async () => {
       // Spy on importPKCS8 to simulate a key import failure.
       const joseModule = require("jose");
-      const spy = jest
-        .spyOn(joseModule, "importPKCS8")
-        .mockImplementation(async () => { throw new Error("Import error"); });
+      const spy = jest.spyOn(joseModule, "importPKCS8").mockImplementation(async () => {
+        throw new Error("Import error");
+      });
       await expect(instance.buildJWT("https://example.com")).rejects.toThrow(
-        InvalidAPIKeyFormatError
+        InvalidAPIKeyFormatError,
       );
       await expect(instance.buildJWT("https://example.com")).rejects.toThrow(
-        "Could not convert the EC private key to PKCS8 format"
+        "Could not convert the EC private key to PKCS8 format",
       );
       spy.mockRestore();
     });
@@ -124,10 +130,10 @@ describe("Authenticator tests", () => {
         .spyOn(SignJWT.prototype, "sign")
         .mockRejectedValue(new Error("Signing error"));
       await expect(instance.buildJWT("https://example.com")).rejects.toThrow(
-        InvalidAPIKeyFormatError
+        InvalidAPIKeyFormatError,
       );
       await expect(instance.buildJWT("https://example.com")).rejects.toThrow(
-        "Could not convert the EC private key to PKCS8 format"
+        "Could not convert the EC private key to PKCS8 format",
       );
       spy.mockRestore();
     });
@@ -156,7 +162,7 @@ describe("Authenticator tests for Edwards key", () => {
   it("should raise InvalidConfiguration error for invalid config", async () => {
     const invalidConfig = {
       method: "GET",
-      url: "", 
+      url: "",
       headers: {} as AxiosHeaders,
     };
     await expect(authenticator.authenticateRequest(invalidConfig)).rejects.toThrow();
@@ -187,20 +193,28 @@ describe("Authenticator tests for Edwards key", () => {
     });
 
     describe("when a source version is provided", () => {
-      beforeAll(() => { sourceVersion = "1.0.0"; });
-      afterAll(() => { sourceVersion = undefined; });
+      beforeAll(() => {
+        sourceVersion = "1.0.0";
+      });
+      afterAll(() => {
+        sourceVersion = undefined;
+      });
 
       it("includes the source version in the correlation context", async () => {
         const config = await authenticator.authenticateRequest(VALID_CONFIG, true);
         const correlationContext = config.headers["Correlation-Context"] as string;
-        expect(correlationContext).toContain("sdk_version=0.20.0,sdk_language=typescript,source=mockSource");
+        expect(correlationContext).toContain(
+          "sdk_version=0.20.0,sdk_language=typescript,source=mockSource",
+        );
       });
     });
 
     it("should raise an InvalidAPIKeyFormat error if Edwards key length is not 64 bytes", async () => {
       const invalidEdKey = privateKey.slice(0, -4);
       const invalidAuthenticator = new CoinbaseAuthenticator(apiKey, invalidEdKey, source);
-      await expect(invalidAuthenticator.authenticateRequest(VALID_CONFIG)).rejects.toThrow(InvalidAPIKeyFormatError);
+      await expect(invalidAuthenticator.authenticateRequest(VALID_CONFIG)).rejects.toThrow(
+        InvalidAPIKeyFormatError,
+      );
     });
 
     describe("#buildJWT", () => {
@@ -214,7 +228,9 @@ describe("Authenticator tests for Edwards key", () => {
       test("should throw error if Edwards key length is not 64 bytes", async () => {
         const invalidEdKey = privateKey.slice(0, -4);
         instance = new CoinbaseAuthenticator(apiKey, invalidEdKey, source);
-        await expect(instance.buildJWT("https://example.com")).rejects.toThrow(InvalidAPIKeyFormatError);
+        await expect(instance.buildJWT("https://example.com")).rejects.toThrow(
+          InvalidAPIKeyFormatError,
+        );
       });
 
       test("should return a valid JWT when building with Edwards key", async () => {

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -1576,7 +1576,7 @@ describe("Wallet Class", () => {
         };
         fs.writeFileSync(filePath, JSON.stringify(incompleteSeedData), "utf8");
         await expect(seedlessWalletForLoad.loadSeedFromFile(filePath)).rejects.toThrow(
-          "Seed data is malformed"
+          "Seed data is malformed",
         );
       });
 
@@ -1592,7 +1592,7 @@ describe("Wallet Class", () => {
         };
         fs.writeFileSync(filePath, JSON.stringify(badEncryptedData), "utf8");
         await expect(seedlessWalletForLoad.loadSeedFromFile(filePath)).rejects.toThrow(
-          "Encrypted seed data is malformed"
+          "Encrypted seed data is malformed",
         );
       });
 
@@ -1608,7 +1608,7 @@ describe("Wallet Class", () => {
         };
         fs.writeFileSync(filePath, JSON.stringify(badEncryptedData), "utf8");
         await expect(seedlessWalletForLoad.loadSeedFromFile(filePath)).rejects.toThrow(
-          "Encrypted seed data is malformed"
+          "Encrypted seed data is malformed",
         );
       });
 


### PR DESCRIPTION
### What changed? Why?
- Right now when a user forgets to call Coinbase.configure, they see an unclear error message because the apiClients aren't defined. This PR uses the proxy pattern in javascript to intercept getting the apiClients, and returns a clear message to the user.

For example:

```
❯ npx ts-node testCreateOnly.ts 
/Users/rohanagarwal/code/coinbase-sdk-nodejs/src/coinbase/coinbase.ts:73
        throw new UninitializedSDKError();
              ^
UninitializedSDKError: Coinbase SDK has not been initialized. Please initialize by calling either:

- Coinbase.configure({apiKeyName: '...', privateKey: '...'})
- Coinbase.configureFromJson({filePath: '/path/to/api_keys.json'})

If needed, register for API keys at https://portal.cdp.coinbase.com/ or view the docs at https://docs.cdp.coinbase.com/wallet-api/docs/welcome
    at Object.get (/Users/rohanagarwal/code/coinbase-sdk-nodejs/src/coinbase/coinbase.ts:73:15)
    at createSmartWallet (/Users/rohanagarwal/code/coinbase-sdk-nodejs/src/wallets/createSmartWallet.ts:40:44)
    at main (/Users/rohanagarwal/code/coinbase-sdk-nodejs/testCreateOnly.ts:14:46)
    at Object.<anonymous> (/Users/rohanagarwal/code/coinbase-sdk-nodejs/testCreateOnly.ts:21:1)
    at Module._compile (node:internal/modules/cjs/loader:1739:14)
    at Module.m._compile (/Users/rohanagarwal/code/coinbase-sdk-nodejs/node_modules/ts-node/src/index.ts:1618:23)
    at loadTS (node:internal/modules/cjs/loader:1831:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/rohanagarwal/code/coinbase-sdk-nodejs/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1473:32)
    at Function._load (node:internal/modules/cjs/loader:1285:12)
```

### Notes to reviewers
- Some of the test files updated were simply for formatting/linting and can be ignored.

### Testing
- Unit test added
- Tested locally, both with and without Coinbase.configure to confirm behavior is correct. 

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
