### PR TITLE
Expose withdrawal creds list validators api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Add `getWithdrawalCredentials` getter for `Validator` object to expose withdrawal credentials of an Ethereum validator. 
+
 ## [0.20.0] - 2025-02-25
 
 ### Added

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1755,11 +1755,17 @@ export interface EthereumValidatorMetadata {
      */
     'public_key': string;
     /**
-     * The address to which the validator\'s rewards are sent.
+     * The 20-byte address to which the validator\'s rewards are sent.
      * @type {string}
      * @memberof EthereumValidatorMetadata
      */
     'withdrawal_address': string;
+    /**
+     * The 32-byte field that determines where and how a validator’s staked ETH and rewards can be withdrawn.
+     * @type {string}
+     * @memberof EthereumValidatorMetadata
+     */
+    'withdrawal_credentials': string;
     /**
      * Whether the validator has been slashed.
      * @type {boolean}

--- a/src/coinbase/validator.ts
+++ b/src/coinbase/validator.ts
@@ -254,6 +254,15 @@ export class Validator {
   }
 
   /**
+   * Returns the withdrawal credentials of the validator.
+   *
+   * @returns The withdrawal credentials as a string.
+   */
+  public getWithdrawalCredentials(): string {
+    return this.model.details?.withdrawal_credentials || "";
+  }
+
+  /**
    * Returns the address for execution layer rewards (MEV & tx fees).If using a reward splitter plan, this is a smart contract
    * address that splits rewards based on defined commissions and send a portion to the forwarded_fee_recipient_address.
    *

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -659,6 +659,7 @@ export function mockEthereumValidator(
       index: index,
       public_key: public_key,
       withdrawal_address: "0xwithdrawal_address_1",
+      withdrawal_credentials: "0x01withdrawal_credentials_1",
       fee_recipient_address: "0xfee_recipient_address_1",
       forwarded_fee_recipient_address: "0xforwarded_fee_recipient_address_1",
       slashed: false,

--- a/src/tests/validator_test.ts
+++ b/src/tests/validator_test.ts
@@ -29,6 +29,7 @@ describe("Validator", () => {
         slashed: false,
         withdrawableEpoch: "epoch-2",
         withdrawal_address: "withdrawal-address-123",
+        withdrawal_credentials: "withdrawal-credentials-123",
         fee_recipient_address: "fee-recipient-address-123",
       },
     };
@@ -78,6 +79,10 @@ describe("Validator", () => {
 
   test("getWithdrawalAddress should return the correct withdrawal address", () => {
     expect(validator.getWithdrawalAddress()).toBe("withdrawal-address-123");
+  });
+
+  test("getWithdrawalCredentials should return the correct withdrawal credentials", () => {
+    expect(validator.getWithdrawalCredentials()).toBe("withdrawal-credentials-123");
   });
 
   test("getFeeRecipientAddress should return the correct fee recipient address", () => {


### PR DESCRIPTION
### What changed? Why?

This PR helps expose withdrawal credentials of ethereum validators in preparation of Pectra. Using this customers can tell if their validator is a 0x01 or a 0x02 validator.

### testing

Example local run

```
> import { Coinbase, ExternalAddress, StakingReward, StakeOptionsMode, Validator, ValidatorStatus, Transaction, Asset, Wallet } from "./src";
undefined

> const coinbase = Coinbase.configureFromJson({ filePath: "~/code/cb/staking/.coinbase_cloud_api_key_production.json" });
undefined

> let validators = await Validator.list("ethereum-mainnet", "eth", ValidatorStatus.ACTIVE);
undefined

> validators.forEach(validator => {console.log(validator.getWithdrawalCredentials()  + " " + validator.getWithdrawalCredentials());});
0x0100000000000000000000007f639032a6d973044b27f90a522b5b4d81466906 0x0100000000000000000000007f639032a6d973044b27f90a522b5b4d81466906
```


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
