### PR TITLE
Upgrade to `@solana/kit` 2.1

### DIFF
--- a/quickstart-template/package-lock.json
+++ b/quickstart-template/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
-        "@coinbase/coinbase-sdk": "^0.8.0",
-        "@solana/web3.js": "^2.0.0-rc.1",
+        "@coinbase/coinbase-sdk": "^0.21.0",
+        "@solana/kit": "^2.1.0",
         "bs58": "^6.0.0",
         "csv-parse": "^5.5.6",
         "csv-writer": "^1.6.0",
@@ -23,12 +23,13 @@
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
     },
     "node_modules/@coinbase/coinbase-sdk": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@coinbase/coinbase-sdk/-/coinbase-sdk-0.8.0.tgz",
-      "integrity": "sha512-O827srI/dW1k5utZTfpv8zWGcxoWVNe+UX04JnMWNx23s5kVrnA9p3us7B7kBgswVDA9e+hk4Ixbr8NH6K5V1A==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@coinbase/coinbase-sdk/-/coinbase-sdk-0.21.0.tgz",
+      "integrity": "sha512-ATyepIy2L9GAY5KNt5O71fB+pdekdfmVR4BHnnID6iOaVD5dE4mV9Mj9H4Wkg0uFy2Fj+F9IVEDqBklaD7lkKw==",
       "license": "ISC",
       "dependencies": {
         "@scure/bip32": "^1.4.0",
+        "abitype": "^1.0.6",
         "axios": "^1.6.8",
         "axios-mock-adapter": "^1.22.0",
         "axios-retry": "^4.4.1",
@@ -36,70 +37,21 @@
         "bip39": "^3.1.0",
         "decimal.js": "^10.4.3",
         "dotenv": "^16.4.5",
+        "ed2curve": "^0.3.0",
         "ethers": "^6.12.1",
-        "node-jose": "^2.2.0",
-        "secp256k1": "^5.0.0"
+        "jose": "^5.10.0",
+        "secp256k1": "^5.0.0",
+        "viem": "^2.21.26"
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.7.1"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/base": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.8.tgz",
-      "integrity": "sha512-6CyAclxj3Nb0XT7GHK6K4zK6k2xJm6E4Ft0Ohjt4WgegiFUHEtFb2CGzmPmGBwoIhrLsqNLYfLr04Y1GePrzZg==",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
-      "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
-      "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
-      "dependencies": {
-        "@noble/hashes": "~1.5.0",
-        "@scure/base": "~1.1.8"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -107,522 +59,762 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@solana/accounts": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.0.0-rc.1.tgz",
-      "integrity": "sha512-au6grz6iIgepKIbN2HUHKatFhg7mvIvdjFMDYpuEx+AGwK7vHnN5PsJqSCGQydthC2nVQwSZC9IgA5MF5wUHdw==",
+    "node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
+      "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "2.0.0-rc.1",
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/rpc-spec": "2.0.0-rc.1",
-        "@solana/rpc-types": "2.0.0-rc.1"
+        "@noble/curves": "~1.8.1",
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
+      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.1.0.tgz",
+      "integrity": "sha512-vqaHROLKp89xdIbaKVG6BQ44uMN9E6/rSTeltkvquD2qdTObssafGDbAKVFjwZhlNO+sdzHDCLekGabn5VAL6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "2.1.0",
+        "@solana/addresses": "2.1.0",
+        "@solana/codecs": "2.1.0",
+        "@solana/errors": "2.1.0",
+        "@solana/functional": "2.1.0",
+        "@solana/instructions": "2.1.0",
+        "@solana/keys": "2.1.0",
+        "@solana/programs": "2.1.0",
+        "@solana/rpc": "2.1.0",
+        "@solana/rpc-parsed-types": "2.1.0",
+        "@solana/rpc-spec-types": "2.1.0",
+        "@solana/rpc-subscriptions": "2.1.0",
+        "@solana/rpc-types": "2.1.0",
+        "@solana/signers": "2.1.0",
+        "@solana/sysvars": "2.1.0",
+        "@solana/transaction-confirmation": "2.1.0",
+        "@solana/transaction-messages": "2.1.0",
+        "@solana/transactions": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/addresses": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.0.0-rc.1.tgz",
-      "integrity": "sha512-g31KrLZdECjAKceShlGoYxnWDmEVklpjPs8xOtnj/HWupEk+Mds4vtmTACTAeJkWZW/3x+z0aexMtO86MKA47g==",
+    "node_modules/@solana/kit/node_modules/@solana/accounts": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.1.0.tgz",
+      "integrity": "sha512-1JOBiLFeIeHmGx7k1b23UWF9vM1HAh9GBMCzr5rBPrGSBs+QUgxBJ3+yrRg+UPEOSELubqo7qoOVFUKYsb1nXw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/assertions": "2.0.0-rc.1",
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/addresses": "2.1.0",
+        "@solana/codecs-core": "2.1.0",
+        "@solana/codecs-strings": "2.1.0",
+        "@solana/errors": "2.1.0",
+        "@solana/rpc-spec": "2.1.0",
+        "@solana/rpc-types": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/assertions": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.0.0-rc.1.tgz",
-      "integrity": "sha512-dvxYCUB7ftZa5lWcsyMYLsGm204H6yVN8Q3ngluMG0rhTtScMBRklVg7Vs39ISwJOkJWJPGToaZ7DjNJ83bm1Q==",
+    "node_modules/@solana/kit/node_modules/@solana/addresses": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.1.0.tgz",
+      "integrity": "sha512-IgiRuju2yLz14GnrysOPSNZbZQ8F+7jhx7FYZLrbKogf6NX4wy4ijLHxRsLFqP8o8aY69BZULkM9MwrSjsZi7A==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/assertions": "2.1.0",
+        "@solana/codecs-core": "2.1.0",
+        "@solana/codecs-strings": "2.1.0",
+        "@solana/errors": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/codecs": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
-      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+    "node_modules/@solana/kit/node_modules/@solana/assertions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.1.0.tgz",
+      "integrity": "sha512-KCYmxFRsg897Ec7yGdpc0rniOlqGD3NpicmIjWIV87uiXX5uFco4t+01sKyFlhsv4T4OgHxngMsxkfQ3AUkFVg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-data-structures": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/options": "2.0.0-rc.1"
+        "@solana/errors": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/codecs-core": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
-      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+    "node_modules/@solana/kit/node_modules/@solana/codecs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.1.0.tgz",
+      "integrity": "sha512-C0TnfrpbTg7zoIFYfM65ofeL2AWEz80OsD6mjVdcTKpb1Uj7XuBuNLss3dMnatPQaL7RagD9VLA5/WfYayyteQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/codecs-core": "2.1.0",
+        "@solana/codecs-data-structures": "2.1.0",
+        "@solana/codecs-numbers": "2.1.0",
+        "@solana/codecs-strings": "2.1.0",
+        "@solana/options": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/codecs-data-structures": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
-      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+    "node_modules/@solana/kit/node_modules/@solana/codecs-core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.1.0.tgz",
+      "integrity": "sha512-SR7pKtmJBg2mhmkel2NeHA1pz06QeQXdMv8WJoIR9m8F/hw80K/612uaYbwTt2nkK0jg/Qn/rNSd7EcJ4SBGjw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/errors": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/codecs-numbers": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
-      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+    "node_modules/@solana/kit/node_modules/@solana/codecs-data-structures": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.1.0.tgz",
+      "integrity": "sha512-oDF5ek54kirqJ09q8k/qEpobBiWOhd3CkkGOTyfjsmTF/IGIigNbdYIakxV3+vudBeaNBw08y0XdBYI4JL/nqA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/codecs-core": "2.1.0",
+        "@solana/codecs-numbers": "2.1.0",
+        "@solana/errors": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/codecs-strings": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
-      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+    "node_modules/@solana/kit/node_modules/@solana/codecs-numbers": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.1.0.tgz",
+      "integrity": "sha512-XMu4yw5iCgQnMKsxSWPPOrGgtaohmupN3eyAtYv3K3C/MJEc5V90h74k5B1GUCiHvcrdUDO9RclNjD9lgbjFag==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/codecs-core": "2.1.0",
+        "@solana/errors": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/codecs-strings": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.1.0.tgz",
+      "integrity": "sha512-O/eJFLzFrHomcCR1Y5QbIqoPo7iaJaWNnIeskB4mVhVjLyjlJS4WtBP2NBRzM9uJXaXyOxxKroqqO9zFsHOpvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.1.0",
+        "@solana/codecs-numbers": "2.1.0",
+        "@solana/errors": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "fastestsmallesttextencoderdecoder": "^1.0.22",
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/errors": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
-      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+    "node_modules/@solana/kit/node_modules/@solana/errors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.1.0.tgz",
+      "integrity": "sha512-l+GxAv0Ar4d3c3PlZdA9G++wFYZREEbbRyAFP8+n8HSg0vudCuzogh/13io6hYuUhG/9Ve8ARZNamhV7UScKNw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
-        "commander": "^12.1.0"
+        "commander": "^13.1.0"
       },
       "bin": {
         "errors": "bin/cli.mjs"
       },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/fast-stable-stringify": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.0.0-rc.1.tgz",
-      "integrity": "sha512-TN8JY+Sbh5NNq4TqdWil8hXKx2d84bTHvY6jfBXNjM29S0fwpUpVRHUzOkuK1mjjWFNkMpfgJfozC0TjdUbkvA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/functional": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.0.0-rc.1.tgz",
-      "integrity": "sha512-BmedS5o8HTlU8/NA22I6urJqat9QYIw0oH6rKdMMBisDwX7MtgJhe38W8iLP7QCcxoJeS4526qaD8uD62+Pheg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/instructions": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.0.0-rc.1.tgz",
-      "integrity": "sha512-zkfL4WBHPbkMrYsuGZc/sekPa/oALIVvVGUw/gwAervMeLZ34cWCUE6WC2uUUh+bq3OFq0/FSFhAg2YbHHDyUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "2.0.0-rc.1"
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/keys": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.0.0-rc.1.tgz",
-      "integrity": "sha512-ls3B0KOvfdiBH3/fnEjHhicfXsLLb4zApJlSX4X8NZ+2TmTJ2Jqa+MakgAzrsxL1FJkTJ1RDboR9xx2CHQtKzw==",
+    "node_modules/@solana/kit/node_modules/@solana/fast-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-a8vR92qbe/VsvQ1BpN3PIEwnoHD2fTHEwCJh9GG58z3R15RIjk73gc0khjcdg4U1tZwTJqWkvk8SbDIgGdOgMA==",
       "license": "MIT",
-      "dependencies": {
-        "@solana/assertions": "2.0.0-rc.1",
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/options": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
-      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+    "node_modules/@solana/kit/node_modules/@solana/functional": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.1.0.tgz",
+      "integrity": "sha512-RVij8Av4F2uUOFcEC8n9lgD72e9gQMritmGHhMh+G91Xops4I6Few+oQ++XgSTiL2t3g3Cs0QZ13onZ0FL45FQ==",
       "license": "MIT",
-      "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-data-structures": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/programs": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.0.0-rc.1.tgz",
-      "integrity": "sha512-wF49DychwSz3sVmTF51R6DTHBGMP7Uhe7EdmCNu+Ef9EgKBJZFfrViOD6M8Q0b3WH//TV63HNlX/2QmHtJjQHg==",
+    "node_modules/@solana/kit/node_modules/@solana/instructions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.1.0.tgz",
+      "integrity": "sha512-wfn6e7Rgm0Sw/Th1v/pXsKTvloZvAAQI7j1yc9WcIk9ngqH5p6LhqMMkrwYPB2oTk8+MMr7SZ4E+2eK2gL6ODA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/codecs-core": "2.1.0",
+        "@solana/errors": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/promises": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.0.0-rc.1.tgz",
-      "integrity": "sha512-iIaC52Ka+omGabGn2LHOSgEm9N2gI7Iyik6LE3DDxZ4MuYmGcJ4E315XuE/UVXWnc9qOfOjgtSaaOYhde0vyrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/rpc": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.0.0-rc.1.tgz",
-      "integrity": "sha512-upqR/Ae5syzQDZkffTdU/09k1Vx073Gt4xkkpcWaTBmW0obVhrlvJvH2k5jrOQ13BZd2NVg1MWMEOBcy3+nJjQ==",
+    "node_modules/@solana/kit/node_modules/@solana/keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.1.0.tgz",
+      "integrity": "sha512-esY1+dlZjB18hZML5p+YPec29wi3HH0SzKx7RiqF//dI2cJ6vHfq3F+7ArbNnF6R2YCLFtl7DzS/tkqR2Xkxeg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/fast-stable-stringify": "2.0.0-rc.1",
-        "@solana/functional": "2.0.0-rc.1",
-        "@solana/rpc-api": "2.0.0-rc.1",
-        "@solana/rpc-spec": "2.0.0-rc.1",
-        "@solana/rpc-transformers": "2.0.0-rc.1",
-        "@solana/rpc-transport-http": "2.0.0-rc.1",
-        "@solana/rpc-types": "2.0.0-rc.1"
+        "@solana/assertions": "2.1.0",
+        "@solana/codecs-core": "2.1.0",
+        "@solana/codecs-strings": "2.1.0",
+        "@solana/errors": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/rpc-api": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.0.0-rc.1.tgz",
-      "integrity": "sha512-pg/w+0pgj3msBCC/hkZa9/qZHRdqh7MLsHMJInXnenO+Rzj6IyE47Ig6rt6GuI4OxYy+1d714jcPXVMA8p2YWw==",
+    "node_modules/@solana/kit/node_modules/@solana/options": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.1.0.tgz",
+      "integrity": "sha512-T/vJCr8qnwK6HxriOPXCrx31IpA9ZYecxuOzQ3G74kIayED4spmpXp6PLtRYR/fo2LZ6UcgHN0qSgONnvwEweg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "2.0.0-rc.1",
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/keys": "2.0.0-rc.1",
-        "@solana/rpc-parsed-types": "2.0.0-rc.1",
-        "@solana/rpc-spec": "2.0.0-rc.1",
-        "@solana/rpc-transformers": "2.0.0-rc.1",
-        "@solana/rpc-types": "2.0.0-rc.1",
-        "@solana/transaction-messages": "2.0.0-rc.1",
-        "@solana/transactions": "2.0.0-rc.1"
+        "@solana/codecs-core": "2.1.0",
+        "@solana/codecs-data-structures": "2.1.0",
+        "@solana/codecs-numbers": "2.1.0",
+        "@solana/codecs-strings": "2.1.0",
+        "@solana/errors": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/rpc-parsed-types": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.0.0-rc.1.tgz",
-      "integrity": "sha512-5/AYNiZvR9do56VJgmTscRwnd9myt6x9uG7b0S3V+K5e0xzA9yJF68SzI4TQSNmLfWXCaVC90xGCWWkM19lLIQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/rpc-spec": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.0.0-rc.1.tgz",
-      "integrity": "sha512-E81IoNzLbp24T633klEqlRujd2i/rd8xVkJGt04DL/LGS4/cCWJEhkmOnfljxWafCPUundRXlPtNG3ZmHzEYqA==",
+    "node_modules/@solana/kit/node_modules/@solana/programs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.1.0.tgz",
+      "integrity": "sha512-9Y30/yUbTR99+QRN2ukNXQQTGY68oKmVrXnh/et6StM1JF5WHvAJqBigsHG5bt6KxTISoRuncBnH/IRnDqPxKg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/rpc-spec-types": "2.0.0-rc.1"
+        "@solana/addresses": "2.1.0",
+        "@solana/errors": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/rpc-spec-types": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.0.0-rc.1.tgz",
-      "integrity": "sha512-Z0gOrzasTYU+kNNnDDG2snZxBoBPMN8oFc0EE9HiDKN9JEsc+asexzKeq+Nea7JVqVFcN5V3bjqrpD86V5EOiQ==",
+    "node_modules/@solana/kit/node_modules/@solana/promises": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.1.0.tgz",
+      "integrity": "sha512-eQJaQXA2kD4dVyifzhslV3wOvq27fwOJ4az89BQ4Cz83zPbR94xOeDShwcXrKBYqaUf6XqH5MzdEo14t4tKAFQ==",
       "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/rpc-subscriptions": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.0.0-rc.1.tgz",
-      "integrity": "sha512-gHrVNWEbMi8uDO8BzpJkuDiHMcfD4SrfLRohROnHx0SfSlEGxvIkBjPnwOYIoS7IkWk95e19s7hJoBNn2TX4kw==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/fast-stable-stringify": "2.0.0-rc.1",
-        "@solana/functional": "2.0.0-rc.1",
-        "@solana/promises": "2.0.0-rc.1",
-        "@solana/rpc-subscriptions-api": "2.0.0-rc.1",
-        "@solana/rpc-subscriptions-spec": "2.0.0-rc.1",
-        "@solana/rpc-subscriptions-transport-websocket": "2.0.0-rc.1",
-        "@solana/rpc-transformers": "2.0.0-rc.1",
-        "@solana/rpc-types": "2.0.0-rc.1"
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/rpc-subscriptions-api": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.0.0-rc.1.tgz",
-      "integrity": "sha512-HmuJmB+RnpYzpiwDWncYFey0lrdFt8KbFvH0JvxEB7NX6V9NgGQIwRY1bfoaeSwX6t93p4nBWr2ckJWLNjXzCw==",
+    "node_modules/@solana/kit/node_modules/@solana/rpc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.1.0.tgz",
+      "integrity": "sha512-myg9qAo6b2WKyHSMXURQykb+ZRnNEXBPLEcwRwkos8STzPPyRFg6ady2s0FCQQTtL/pVjanIU2bObZIzbMGugA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "2.0.0-rc.1",
-        "@solana/keys": "2.0.0-rc.1",
-        "@solana/rpc-subscriptions-spec": "2.0.0-rc.1",
-        "@solana/rpc-transformers": "2.0.0-rc.1",
-        "@solana/rpc-types": "2.0.0-rc.1",
-        "@solana/transaction-messages": "2.0.0-rc.1",
-        "@solana/transactions": "2.0.0-rc.1"
+        "@solana/errors": "2.1.0",
+        "@solana/fast-stable-stringify": "2.1.0",
+        "@solana/functional": "2.1.0",
+        "@solana/rpc-api": "2.1.0",
+        "@solana/rpc-spec": "2.1.0",
+        "@solana/rpc-spec-types": "2.1.0",
+        "@solana/rpc-transformers": "2.1.0",
+        "@solana/rpc-transport-http": "2.1.0",
+        "@solana/rpc-types": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/rpc-subscriptions-spec": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.0.0-rc.1.tgz",
-      "integrity": "sha512-eXRVlMr9zw4JlBoJgVhFRxFs3Iaowhtt35ZIMD+OoTqgKniL62iGiZ3hXsuMDToMvQCBd0UfI+ZVdF2gLQdg9A==",
+    "node_modules/@solana/kit/node_modules/@solana/rpc-api": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.1.0.tgz",
+      "integrity": "sha512-4yCnHYHFlz9VffivoY5q/HVeBjT59byB2gmg7UyC3ktxD28AlF9jjsE5tJKiapAKr2J3KWm0D/rH/QwW14cGeA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/rpc-spec-types": "2.0.0-rc.1"
+        "@solana/addresses": "2.1.0",
+        "@solana/codecs-core": "2.1.0",
+        "@solana/codecs-strings": "2.1.0",
+        "@solana/errors": "2.1.0",
+        "@solana/keys": "2.1.0",
+        "@solana/rpc-parsed-types": "2.1.0",
+        "@solana/rpc-spec": "2.1.0",
+        "@solana/rpc-transformers": "2.1.0",
+        "@solana/rpc-types": "2.1.0",
+        "@solana/transaction-messages": "2.1.0",
+        "@solana/transactions": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/rpc-subscriptions-transport-websocket": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-transport-websocket/-/rpc-subscriptions-transport-websocket-2.0.0-rc.1.tgz",
-      "integrity": "sha512-NxheQmG6Ku9gjF3TyGbM8Nxx6fOU3m89LdfH9SQNu6yME6VXKWuT1LaY24T707yDOoKZJsOWabRrQtNfJ+3HZA==",
+    "node_modules/@solana/kit/node_modules/@solana/rpc-parsed-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.1.0.tgz",
+      "integrity": "sha512-mRzHemxlWDS9p1fPQNKwL+1vEOUMG8peSUJb0X/NbM12yjowDNdzM++fkOgIyCKDPddfkcoNmNrQmr2jwjdN1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-spec": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.1.0.tgz",
+      "integrity": "sha512-NPAIM5EY7Jke0mHnmoMpgCEb/nZKIo+bgVFK/u+z74gY0JnCNt0DfocStUUQtlhqSmTyoHamt3lfxp4GT2zXbA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/rpc-subscriptions-spec": "2.0.0-rc.1"
+        "@solana/errors": "2.1.0",
+        "@solana/rpc-spec-types": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-spec-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.1.0.tgz",
+      "integrity": "sha512-NxcZ8piXMyCdbNUL6d36QJfL2UAQEN33StlGku0ltTVe1nrokZ5WRNjSPohU1fODlNaZzTvUFzvUkM1yGCkyzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-subscriptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.1.0.tgz",
+      "integrity": "sha512-dTyI03VlueE3s7mA/OBlA5l6yKUUKHMJd31tpzxV3AFnqE/QPS5NVrF/WY6pPBobLJiCP0UFOe7eR/MKP9SUCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.1.0",
+        "@solana/fast-stable-stringify": "2.1.0",
+        "@solana/functional": "2.1.0",
+        "@solana/promises": "2.1.0",
+        "@solana/rpc-spec-types": "2.1.0",
+        "@solana/rpc-subscriptions-api": "2.1.0",
+        "@solana/rpc-subscriptions-channel-websocket": "2.1.0",
+        "@solana/rpc-subscriptions-spec": "2.1.0",
+        "@solana/rpc-transformers": "2.1.0",
+        "@solana/rpc-types": "2.1.0",
+        "@solana/subscribable": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-subscriptions-api": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.1.0.tgz",
+      "integrity": "sha512-de1dBRSE2CUwoZHMXQ/0v7iC+/pG0+iYY8jLHGGNxtKrYbTnV08mXQbaAMrmv2Rk8ZFmfJWbqbYZ9dRWdO3P5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.1.0",
+        "@solana/keys": "2.1.0",
+        "@solana/rpc-subscriptions-spec": "2.1.0",
+        "@solana/rpc-transformers": "2.1.0",
+        "@solana/rpc-types": "2.1.0",
+        "@solana/transaction-messages": "2.1.0",
+        "@solana/transactions": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.1.0.tgz",
+      "integrity": "sha512-goJe9dv0cs967HJ382vSX8yapXgQzRHCmH323LsXrrpj/s3Eb3yUwJq7AcHgoh4gKIqyAfGybq/bE5Aa8Pcm9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.1.0",
+        "@solana/functional": "2.1.0",
+        "@solana/rpc-subscriptions-spec": "2.1.0",
+        "@solana/subscribable": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5",
-        "ws": "^8.14.0"
+        "ws": "^8.18.0"
       }
     },
-    "node_modules/@solana/rpc-transformers": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.0.0-rc.1.tgz",
-      "integrity": "sha512-YM25X4Eeh39UR2AoSrCFn74W99bQk0/DLqyPgZpNBRbszzEifGHqu83NNFwBuPMVc9q7ilf5s6r6pqhWP+5JJw==",
+    "node_modules/@solana/kit/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.1.0.tgz",
+      "integrity": "sha512-Uqasfd3Tlr22lC/Vy5dToF0e68dMKPdnt4ks7FwXuPdEbNRM/TDGb0GqG+bt/d3IIrNOCA5Y8vsE0nQHGrWG/w==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/functional": "2.0.0-rc.1",
-        "@solana/rpc-spec": "2.0.0-rc.1",
-        "@solana/rpc-subscriptions-spec": "2.0.0-rc.1",
-        "@solana/rpc-types": "2.0.0-rc.1"
+        "@solana/errors": "2.1.0",
+        "@solana/promises": "2.1.0",
+        "@solana/rpc-spec-types": "2.1.0",
+        "@solana/subscribable": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/rpc-transport-http": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.0.0-rc.1.tgz",
-      "integrity": "sha512-Byvn2LnaCgTnEyr78wcgh8SrVHo+L6/l1kXQW05cNAjjbS8d8z4meBUBrXDWHmCsWy7RdnrTcBixPPtE+pUebw==",
+    "node_modules/@solana/kit/node_modules/@solana/rpc-transformers": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.1.0.tgz",
+      "integrity": "sha512-E2xPlaCu6tNO00v4HIJxJCYkoNwgVJYad5sxbIUZOQBWwXnWIcll2jUT4bWKpBGq5vFDYfkzRBr8Rco3DhfXqg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/rpc-spec": "2.0.0-rc.1",
-        "undici-types": "^6.19.5"
+        "@solana/errors": "2.1.0",
+        "@solana/functional": "2.1.0",
+        "@solana/rpc-spec-types": "2.1.0",
+        "@solana/rpc-types": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/rpc-types": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.0.0-rc.1.tgz",
-      "integrity": "sha512-EcGx9VXqA0+uYEdaa1lKTaGBVxLyNL8nkecE4GkqQ+ntRyYlNBPecd4b8siQGSleUQa+Tk/VSPUawSkHqNTLug==",
+    "node_modules/@solana/kit/node_modules/@solana/rpc-transport-http": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.1.0.tgz",
+      "integrity": "sha512-E3UovTBid4/S8QDd9FkADVKfyG+v7CW5IqI4c27ZDKfazCsnDLLkqh98C6BvNCqi278HKBui4lI2GoFpCq89Pw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "2.0.0-rc.1",
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/errors": "2.1.0",
+        "@solana/rpc-spec": "2.1.0",
+        "@solana/rpc-spec-types": "2.1.0",
+        "undici-types": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/signers": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.0.0-rc.1.tgz",
-      "integrity": "sha512-dv3oKSF+AIaHKpnSkmzEf+jXVcA3nl015+Mp/WQZYzQJS01dlrmnd4N5DOSn2CaPRJ0TLujHkupxkOFXbe149A==",
+    "node_modules/@solana/kit/node_modules/@solana/rpc-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.1.0.tgz",
+      "integrity": "sha512-1ODnhmpR1X/GjB7hs4gVR3mcCagfPQV0dzq/2DNuCiMjx2snn64KP5WoAHfBEyoC9/Rb36+JpNj/hLAOikipKA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "2.0.0-rc.1",
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/instructions": "2.0.0-rc.1",
-        "@solana/keys": "2.0.0-rc.1",
-        "@solana/transaction-messages": "2.0.0-rc.1",
-        "@solana/transactions": "2.0.0-rc.1"
+        "@solana/addresses": "2.1.0",
+        "@solana/codecs-core": "2.1.0",
+        "@solana/codecs-numbers": "2.1.0",
+        "@solana/codecs-strings": "2.1.0",
+        "@solana/errors": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/sysvars": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.0.0-rc.1.tgz",
-      "integrity": "sha512-nLiuisgbRw7FkJrxPJOBzf0ro7ZCk0gWgMyLQexe9oPoTzdZnWbHI4ldYDmtfdy2dkPBsNTz6sZ6o75HwnGu0A==",
+    "node_modules/@solana/kit/node_modules/@solana/signers": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.1.0.tgz",
+      "integrity": "sha512-Yq0JdJnCecRsSBshNWy+OIRmAGeVfjwIh9Z+H1jv8u8p+dJCOreKakTWuxMt5tnj3q5K1mPcak9O2PqVPZ0teA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/accounts": "2.0.0-rc.1",
-        "@solana/codecs": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/rpc-types": "2.0.0-rc.1"
+        "@solana/addresses": "2.1.0",
+        "@solana/codecs-core": "2.1.0",
+        "@solana/errors": "2.1.0",
+        "@solana/instructions": "2.1.0",
+        "@solana/keys": "2.1.0",
+        "@solana/transaction-messages": "2.1.0",
+        "@solana/transactions": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/transaction-confirmation": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.0.0-rc.1.tgz",
-      "integrity": "sha512-ES671CZUDLaXV46Vv3Kxd22coSQE4DlE7y0s9ChzQ7t4bLGv6DeHlHXU9kQBtou9koLR25wiDUWtvwNUyzUbHw==",
+    "node_modules/@solana/kit/node_modules/@solana/sysvars": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.1.0.tgz",
+      "integrity": "sha512-GXu9yS0zIebmM1Unqw/XFpYuvug03m42w98ioOPV/yiHzECggGRGpHGD9RLVYnkyz0eL4NRbnJ5dAEu/fvGe0A==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/keys": "2.0.0-rc.1",
-        "@solana/promises": "2.0.0-rc.1",
-        "@solana/rpc": "2.0.0-rc.1",
-        "@solana/rpc-subscriptions": "2.0.0-rc.1",
-        "@solana/rpc-types": "2.0.0-rc.1",
-        "@solana/transaction-messages": "2.0.0-rc.1",
-        "@solana/transactions": "2.0.0-rc.1"
+        "@solana/accounts": "2.1.0",
+        "@solana/codecs": "2.1.0",
+        "@solana/errors": "2.1.0",
+        "@solana/rpc-types": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/transaction-messages": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.0.0-rc.1.tgz",
-      "integrity": "sha512-pZTetOtRDwfuK/fyE8FKbtRsLQOTgEIQld3tskB85npUHaEgrnCYzp3nJtMhKOLel3w3f/27VtWLNSrRyyAiew==",
+    "node_modules/@solana/kit/node_modules/@solana/transaction-confirmation": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.1.0.tgz",
+      "integrity": "sha512-VxOvtvs2e9h5u73PHyE2TptLAMO5x6dOXlOgvq1Nk6l3rKM2HAsd+KDpN7gjOo8/EgItMMmyEilXygWWRgpSIA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "2.0.0-rc.1",
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-data-structures": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/functional": "2.0.0-rc.1",
-        "@solana/instructions": "2.0.0-rc.1",
-        "@solana/rpc-types": "2.0.0-rc.1"
+        "@solana/addresses": "2.1.0",
+        "@solana/codecs-strings": "2.1.0",
+        "@solana/errors": "2.1.0",
+        "@solana/keys": "2.1.0",
+        "@solana/promises": "2.1.0",
+        "@solana/rpc": "2.1.0",
+        "@solana/rpc-subscriptions": "2.1.0",
+        "@solana/rpc-types": "2.1.0",
+        "@solana/transaction-messages": "2.1.0",
+        "@solana/transactions": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/transactions": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.0.0-rc.1.tgz",
-      "integrity": "sha512-u9MH2Kk4P0E5rNxATdx/ljR2rp34S9VuC3Jzj9nCMKJ0XwvCD+ddTmIDop5Vs+96Ls9SGj0XaKAJtT+9S7SDpw==",
+    "node_modules/@solana/kit/node_modules/@solana/transaction-messages": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.1.0.tgz",
+      "integrity": "sha512-+GPzZHLYNFbqHKoiL8mYALp7eAXtAbI6zLViZpIM3zUbVNU3q5+FCKGv6jCBnxs+3QCbeapu+W1OyfDa6BUtTQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "2.0.0-rc.1",
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-data-structures": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/functional": "2.0.0-rc.1",
-        "@solana/instructions": "2.0.0-rc.1",
-        "@solana/keys": "2.0.0-rc.1",
-        "@solana/rpc-types": "2.0.0-rc.1",
-        "@solana/transaction-messages": "2.0.0-rc.1"
+        "@solana/addresses": "2.1.0",
+        "@solana/codecs-core": "2.1.0",
+        "@solana/codecs-data-structures": "2.1.0",
+        "@solana/codecs-numbers": "2.1.0",
+        "@solana/errors": "2.1.0",
+        "@solana/functional": "2.1.0",
+        "@solana/instructions": "2.1.0",
+        "@solana/rpc-types": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
       }
     },
-    "node_modules/@solana/web3.js": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-2.0.0-rc.1.tgz",
-      "integrity": "sha512-0fE40ZsJuqSOYOWbt8haHBIbhSfGckxJbwWEK+xRQaWr1sY1+MPUDnBawsLf818g9KRSNnS2Y3+/Sve7A3yfBA==",
+    "node_modules/@solana/kit/node_modules/@solana/transactions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.1.0.tgz",
+      "integrity": "sha512-QeM4sCItReeIy5LU7LhGkz7RPfMPTg/Qo8h0LSfhiJiPTOHOhElmh42vkLJmwPl83+MsKtisyPQNK6penM2nAw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/accounts": "2.0.0-rc.1",
-        "@solana/addresses": "2.0.0-rc.1",
-        "@solana/codecs": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1",
-        "@solana/functional": "2.0.0-rc.1",
-        "@solana/instructions": "2.0.0-rc.1",
-        "@solana/keys": "2.0.0-rc.1",
-        "@solana/programs": "2.0.0-rc.1",
-        "@solana/rpc": "2.0.0-rc.1",
-        "@solana/rpc-parsed-types": "2.0.0-rc.1",
-        "@solana/rpc-subscriptions": "2.0.0-rc.1",
-        "@solana/rpc-types": "2.0.0-rc.1",
-        "@solana/signers": "2.0.0-rc.1",
-        "@solana/sysvars": "2.0.0-rc.1",
-        "@solana/transaction-confirmation": "2.0.0-rc.1",
-        "@solana/transaction-messages": "2.0.0-rc.1",
-        "@solana/transactions": "2.0.0-rc.1"
+        "@solana/addresses": "2.1.0",
+        "@solana/codecs-core": "2.1.0",
+        "@solana/codecs-data-structures": "2.1.0",
+        "@solana/codecs-numbers": "2.1.0",
+        "@solana/codecs-strings": "2.1.0",
+        "@solana/errors": "2.1.0",
+        "@solana/functional": "2.1.0",
+        "@solana/instructions": "2.1.0",
+        "@solana/keys": "2.1.0",
+        "@solana/rpc-types": "2.1.0",
+        "@solana/transaction-messages": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/kit/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/kit/node_modules/undici-types": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.5.0.tgz",
+      "integrity": "sha512-CxNFga24pkqrtk9aO4jV78tWXLZhVVU9J2/EAhBGwqJ1+tsLydMI2Vaq7wj3ba/SZL7BL8aq5rflf75DhbgkhA==",
+      "license": "MIT"
+    },
+    "node_modules/@solana/kit/node_modules/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.1.0.tgz",
+      "integrity": "sha512-xi12Cm889+uT5sRKnIzr7nLnHAp3hiR3dqIzrT1P7z7iEGp8OnqUQIQCHlgozFHM2cPW+6685NQXk1l1ImuJIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/subscribable/node_modules/@solana/errors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.1.0.tgz",
+      "integrity": "sha512-l+GxAv0Ar4d3c3PlZdA9G++wFYZREEbbRyAFP8+n8HSg0vudCuzogh/13io6hYuUhG/9Ve8ARZNamhV7UScKNw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^13.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/subscribable/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@types/node": {
@@ -631,9 +823,10 @@
       "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
     },
     "node_modules/abitype": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.5.tgz",
-      "integrity": "sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
+      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -698,33 +891,6 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
       "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ==",
       "license": "MIT"
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/base64url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/bip32": {
       "version": "4.0.0",
@@ -795,29 +961,6 @@
         "base-x": "^3.0.2"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/chalk": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
@@ -848,15 +991,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/create-hash": {
@@ -905,6 +1039,15 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/ed2curve": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
+      "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "tweetnacl": "1.x.x"
+      }
+    },
     "node_modules/elliptic": {
       "version": "6.5.6",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
@@ -918,11 +1061,6 @@
         "minimalistic-assert": "^1.0.1",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/ethers": {
       "version": "6.13.1",
@@ -972,6 +1110,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1049,25 +1193,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1107,28 +1232,28 @@
       }
     },
     "node_modules/isows": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.4.tgz",
-      "integrity": "sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
+      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
       "funding": [
         {
           "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
+          "url": "https://github.com/sponsors/wevm"
         }
       ],
+      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -1174,14 +1299,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
-    "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/node-gyp-build": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
@@ -1192,33 +1309,33 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
-    "node_modules/node-jose": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-2.2.0.tgz",
-      "integrity": "sha512-XPCvJRr94SjLrSIm4pbYHKLEaOsDvJCpyFw/6V/KK/IXmyZ6SFBzAUDO9HQf4DB/nTEFcRGH87mNciOP23kFjw==",
+    "node_modules/ox": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
+      "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "base64url": "^3.0.1",
-        "buffer": "^6.0.3",
-        "es6-promise": "^4.2.8",
-        "lodash": "^4.17.21",
-        "long": "^5.2.0",
-        "node-forge": "^1.2.1",
-        "pako": "^2.0.4",
-        "process": "^0.11.10",
-        "uuid": "^9.0.0"
-      }
-    },
-    "node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "engines": {
-        "node": ">= 0.6.0"
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/proxy-from-env": {
@@ -1306,6 +1423,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
     "node_modules/typeforce": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
@@ -1325,49 +1448,31 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/viem": {
-      "version": "2.21.6",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.6.tgz",
-      "integrity": "sha512-YX48IVl6nZ4FRsY4ypv2RrxtQVWysIY146/lBW53tma8u32h8EsiA7vecw9ZbrueNUy/asHR4Egu68Z6FOvDzQ==",
+      "version": "2.23.13",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.13.tgz",
+      "integrity": "sha512-f3RkcrzGhU79GfBb9GHUL0m3e3LUsNudXIQTFp4fit5hUGb0ew9KOYZ6cCY5d4Melj3noBy2zq0K2fV+mp+Cpg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@adraffy/ens-normalize": "1.10.0",
-        "@noble/curves": "1.4.0",
-        "@noble/hashes": "1.4.0",
-        "@scure/bip32": "1.4.0",
-        "@scure/bip39": "1.4.0",
-        "abitype": "1.0.5",
-        "isows": "1.0.4",
-        "webauthn-p256": "0.0.5",
-        "ws": "8.17.1"
+        "@noble/curves": "1.8.1",
+        "@noble/hashes": "1.7.1",
+        "@scure/bip32": "1.6.2",
+        "@scure/bip39": "1.5.4",
+        "abitype": "1.0.8",
+        "isows": "1.0.6",
+        "ox": "0.6.9",
+        "ws": "8.18.1"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -1378,35 +1483,25 @@
         }
       }
     },
-    "node_modules/viem/node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
-      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
-    },
-    "node_modules/viem/node_modules/@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/webauthn-p256": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/webauthn-p256/-/webauthn-p256-0.0.5.tgz",
-      "integrity": "sha512-drMGNWKdaixZNobeORVIqq7k5DsRC9FnG201K2QjeOoQLmtSDaSsVZdkg6n5jUALJKcAG++zBPJXmv6hy0nWFg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
         }
-      ],
-      "dependencies": {
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0"
       }
     },
     "node_modules/wif": {

--- a/quickstart-template/package.json
+++ b/quickstart-template/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "@solana/web3.js": "^2.0.0-rc.1",
+    "@solana/kit": "^2.1.0",
     "bs58": "^6.0.0",
     "@coinbase/coinbase-sdk": "^0.21.0",
     "csv-parse": "^5.5.6",

--- a/quickstart-template/solana_stake.ts
+++ b/quickstart-template/solana_stake.ts
@@ -6,7 +6,7 @@ import {
   getBase64EncodedWireTransaction,
   getTransactionDecoder,
   signTransaction,
-} from "@solana/web3.js";
+} from "@solana/kit";
 import * as bs58 from "bs58";
 import { NetworkIdentifier } from "@coinbase/coinbase-sdk/dist/client";
 

--- a/quickstart-template/solana_wallet.ts
+++ b/quickstart-template/solana_wallet.ts
@@ -1,4 +1,4 @@
-import { KeyPairSigner, createKeyPairSignerFromBytes } from "@solana/web3.js";
+import { KeyPairSigner, createKeyPairSignerFromBytes } from "@solana/kit";
 import { readFileSync } from "fs";
 import { homedir } from "os";
 import { env } from "process";


### PR DESCRIPTION
### What changed? Why?

`@solana/web3.js@2` has been renamed to `@solana/kit`, but is otherwise API compatible.