### PR TITLE
chore: use GH Environment for NPM Publication GHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
### What changed? Why?
- Use `npm` GH environment for NPM publication GHA

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
