### PR TITLE
chore: fix how options are parsed when not doing native eth unstake v2

### DIFF
--- a/src/coinbase/address/external_address.ts
+++ b/src/coinbase/address/external_address.ts
@@ -3,7 +3,7 @@ import { Amount, BroadcastExternalTransactionResponse, StakeOptionsMode } from "
 import { Coinbase } from "../coinbase";
 import Decimal from "decimal.js";
 import { Asset } from "../asset";
-import { HasWithdrawalCredentialType0x02Option, StakingOperation } from "../staking_operation";
+import { IsNativeEthUnstakeV2, StakingOperation } from "../staking_operation";
 
 /**
  * A representation of a blockchain Address, which is a user-controlled account on a Network. Addresses are used to
@@ -63,7 +63,8 @@ export class ExternalAddress extends Address {
     mode: StakeOptionsMode = StakeOptionsMode.DEFAULT,
     options: { [key: string]: string } = {},
   ): Promise<StakingOperation> {
-    if (!HasWithdrawalCredentialType0x02Option(options)) {
+    // If performing a native eth unstake v2, validation is always performed server-side.
+    if (!IsNativeEthUnstakeV2(assetId, "unstake", mode, options)) {
       await this.validateCanUnstake(amount, assetId, mode, options);
     }
     return this.buildStakingOperation(amount, assetId, "unstake", mode, options);
@@ -117,7 +118,8 @@ export class ExternalAddress extends Address {
 
     newOptions.mode = mode;
 
-    if (!HasWithdrawalCredentialType0x02Option(options)) {
+    // If performing a native eth unstake v2, the amount is not required.
+    if (!IsNativeEthUnstakeV2(assetId, action, mode, newOptions)) {
       const stakingAmount = new Decimal(amount.toString());
       if (stakingAmount.lessThanOrEqualTo(0)) {
         throw new Error(`Amount required greater than zero.`);

--- a/src/coinbase/address/external_address.ts
+++ b/src/coinbase/address/external_address.ts
@@ -3,7 +3,7 @@ import { Amount, BroadcastExternalTransactionResponse, StakeOptionsMode } from "
 import { Coinbase } from "../coinbase";
 import Decimal from "decimal.js";
 import { Asset } from "../asset";
-import { IsNativeEthUnstakeV2, StakingOperation } from "../staking_operation";
+import { IsDedicatedEthUnstakeV2Operation, StakingOperation } from "../staking_operation";
 
 /**
  * A representation of a blockchain Address, which is a user-controlled account on a Network. Addresses are used to
@@ -64,7 +64,7 @@ export class ExternalAddress extends Address {
     options: { [key: string]: string } = {},
   ): Promise<StakingOperation> {
     // If performing a native eth unstake v2, validation is always performed server-side.
-    if (!IsNativeEthUnstakeV2(assetId, "unstake", mode, options)) {
+    if (!IsDedicatedEthUnstakeV2Operation(assetId, "unstake", mode, options)) {
       await this.validateCanUnstake(amount, assetId, mode, options);
     }
     return this.buildStakingOperation(amount, assetId, "unstake", mode, options);
@@ -119,7 +119,7 @@ export class ExternalAddress extends Address {
     newOptions.mode = mode;
 
     // If performing a native eth unstake v2, the amount is not required.
-    if (!IsNativeEthUnstakeV2(assetId, action, mode, newOptions)) {
+    if (!IsDedicatedEthUnstakeV2Operation(assetId, action, mode, newOptions)) {
       const stakingAmount = new Decimal(amount.toString());
       if (stakingAmount.lessThanOrEqualTo(0)) {
         throw new Error(`Amount required greater than zero.`);

--- a/src/coinbase/address/wallet_address.ts
+++ b/src/coinbase/address/wallet_address.ts
@@ -26,7 +26,7 @@ import {
 } from "../types";
 import { delay } from "../utils";
 import { Wallet as WalletClass } from "../wallet";
-import { HasWithdrawalCredentialType0x02Option, StakingOperation } from "../staking_operation";
+import { HasWithdrawalCredentialType0x02Option, IsNativeEthUnstakeV2, StakingOperation } from "../staking_operation";
 import { PayloadSignature } from "../payload_signature";
 import { SmartContract } from "../smart_contract";
 import { FundOperation } from "../fund_operation";
@@ -716,7 +716,8 @@ export class WalletAddress extends Address {
     timeoutSeconds = 600,
     intervalSeconds = 0.2,
   ): Promise<StakingOperation> {
-    if (!HasWithdrawalCredentialType0x02Option(options)) {
+    // If performing a native ETH unstake, validation is always performed server-side.
+    if (!IsNativeEthUnstakeV2(assetId, "unstake", mode, options)) {
       await this.validateCanUnstake(amount, assetId, mode, options);
     }
     return this.createStakingOperation(
@@ -1010,7 +1011,8 @@ export class WalletAddress extends Address {
     timeoutSeconds: number,
     intervalSeconds: number,
   ): Promise<StakingOperation> {
-    if (!HasWithdrawalCredentialType0x02Option(options)) {
+    // If performing a native ETH unstake, the amount is not required.
+    if (!IsNativeEthUnstakeV2(assetId, action, mode, options)) {
       if (new Decimal(amount.toString()).lessThanOrEqualTo(0)) {
         throw new Error("Amount required greater than zero.");
       }
@@ -1078,7 +1080,8 @@ export class WalletAddress extends Address {
 
     options.mode = mode ? mode : StakeOptionsMode.DEFAULT;
 
-    if (!HasWithdrawalCredentialType0x02Option(options)) {
+    // If performing a native ETH unstake, the amount is not required.
+    if (!IsNativeEthUnstakeV2(assetId, action, mode, options)) {
       options.amount = asset.toAtomicAmount(new Decimal(amount.toString())).toString();
     }
 

--- a/src/coinbase/address/wallet_address.ts
+++ b/src/coinbase/address/wallet_address.ts
@@ -26,7 +26,7 @@ import {
 } from "../types";
 import { delay } from "../utils";
 import { Wallet as WalletClass } from "../wallet";
-import { HasWithdrawalCredentialType0x02Option, IsNativeEthUnstakeV2, StakingOperation } from "../staking_operation";
+import { HasWithdrawalCredentialType0x02Option, IsDedicatedEthUnstakeV2Operation, StakingOperation } from "../staking_operation";
 import { PayloadSignature } from "../payload_signature";
 import { SmartContract } from "../smart_contract";
 import { FundOperation } from "../fund_operation";
@@ -717,7 +717,7 @@ export class WalletAddress extends Address {
     intervalSeconds = 0.2,
   ): Promise<StakingOperation> {
     // If performing a native ETH unstake, validation is always performed server-side.
-    if (!IsNativeEthUnstakeV2(assetId, "unstake", mode, options)) {
+    if (!IsDedicatedEthUnstakeV2Operation(assetId, "unstake", mode, options)) {
       await this.validateCanUnstake(amount, assetId, mode, options);
     }
     return this.createStakingOperation(
@@ -1012,7 +1012,7 @@ export class WalletAddress extends Address {
     intervalSeconds: number,
   ): Promise<StakingOperation> {
     // If performing a native ETH unstake, the amount is not required.
-    if (!IsNativeEthUnstakeV2(assetId, action, mode, options)) {
+    if (!IsDedicatedEthUnstakeV2Operation(assetId, action, mode, options)) {
       if (new Decimal(amount.toString()).lessThanOrEqualTo(0)) {
         throw new Error("Amount required greater than zero.");
       }
@@ -1081,7 +1081,7 @@ export class WalletAddress extends Address {
     options.mode = mode ? mode : StakeOptionsMode.DEFAULT;
 
     // If performing a native ETH unstake, the amount is not required.
-    if (!IsNativeEthUnstakeV2(assetId, action, mode, options)) {
+    if (!IsDedicatedEthUnstakeV2Operation(assetId, action, mode, options)) {
       options.amount = asset.toAtomicAmount(new Decimal(amount.toString())).toString();
     }
 

--- a/src/coinbase/staking_operation.ts
+++ b/src/coinbase/staking_operation.ts
@@ -31,7 +31,7 @@ export function HasWithdrawalCredentialType0x02Option(options: { [key: string]: 
  * @param options - An object containing various options.
  * @returns True if the parameters represent a native ETH unstake operation (version 2), false otherwise.
  */
-export function IsNativeEthUnstakeV2(
+export function IsDedicatedEthUnstakeV2Operation(
   assetId: string,
   action: string,
   mode: string,

--- a/src/coinbase/staking_operation.ts
+++ b/src/coinbase/staking_operation.ts
@@ -6,7 +6,7 @@ import {
 import { Transaction } from "./transaction";
 import { Coinbase } from "./coinbase";
 import { delay } from "./utils";
-import { Amount } from "./types";
+import { Amount, StakeOptionsMode } from "./types";
 import { Asset } from "./asset";
 import Decimal from "decimal.js";
 
@@ -20,6 +20,29 @@ export const WithdrawalCredentialType0x02 = "0x02";
  */
 export function HasWithdrawalCredentialType0x02Option(options: { [key: string]: string }): boolean {
   return options["withdrawal_credential_type"] === WithdrawalCredentialType0x02;
+}
+
+/**
+ * Determines if the given parameters represent a native ETH unstake operation (version 2).
+ *
+ * @param assetId - The ID of the asset.
+ * @param action - The action being performed.
+ * @param mode - The mode of the stake options.
+ * @param options - An object containing various options.
+ * @returns True if the parameters represent a native ETH unstake operation (version 2), false otherwise.
+ */
+export function IsNativeEthUnstakeV2(
+  assetId: string,
+  action: string,
+  mode: string,
+  options: { [key: string]: string },
+): boolean {
+  return (
+    assetId === Coinbase.assets.Eth &&
+    action == "unstake" &&
+    mode === StakeOptionsMode.NATIVE &&
+    HasWithdrawalCredentialType0x02Option(options)
+  );
 }
 
 /**

--- a/src/tests/external_address_test.ts
+++ b/src/tests/external_address_test.ts
@@ -35,7 +35,7 @@ describe("ExternalAddress", () => {
   const STAKING_CONTEXT_MODEL: StakingContextModel = {
     context: {
       stakeable_balance: {
-        amount: "3000000000000000000",
+        amount: "128000000000000000000",
         asset: {
           asset_id: Coinbase.assets.Eth,
           network_id: Coinbase.networks.EthereumHolesky,
@@ -233,11 +233,87 @@ describe("ExternalAddress", () => {
       expect(op).toBeInstanceOf(StakingOperation);
     });
 
+    describe("native eth staking", () => {
+      it("should successfully build an 0x01 stake operation", async () => {
+        Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
+        Coinbase.apiClients.stake!.buildStakingOperation = mockReturnValue(STAKING_OPERATION_MODEL);
+        Coinbase.apiClients.asset!.getAsset = getAssetMock();
+        const op = await address.buildStakeOperation(
+          new Decimal("32"),
+          Coinbase.assets.Eth,
+          StakeOptionsMode.NATIVE,
+          {
+            withdrawal_credential_type: "0x01",
+          },
+        );
+
+        expect(Coinbase.apiClients.stake!.getStakingContext).toHaveBeenCalledWith({
+          address_id: address.getId(),
+          network_id: address.getNetworkId(),
+          asset_id: Coinbase.assets.Eth,
+          options: {
+            mode: StakeOptionsMode.NATIVE,
+            withdrawal_credential_type: "0x01",
+          },
+        });
+        expect(Coinbase.apiClients.stake!.buildStakingOperation).toHaveBeenCalledWith({
+          address_id: address.getId(),
+          network_id: address.getNetworkId(),
+          asset_id: Coinbase.assets.Eth,
+          action: "stake",
+          options: {
+            mode: StakeOptionsMode.NATIVE,
+            amount: "32000000000000000000",
+            withdrawal_credential_type: "0x01",
+          },
+        });
+
+        expect(op).toBeInstanceOf(StakingOperation);
+      });
+
+      it("should successfully build an 0x02 stake operation", async () => {
+        Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
+        Coinbase.apiClients.stake!.buildStakingOperation = mockReturnValue(STAKING_OPERATION_MODEL);
+        Coinbase.apiClients.asset!.getAsset = getAssetMock();
+        const op = await address.buildStakeOperation(
+          new Decimal("64"),
+          Coinbase.assets.Eth,
+          StakeOptionsMode.NATIVE,
+          {
+            withdrawal_credential_type: "0x02",
+          },
+        );
+
+        expect(Coinbase.apiClients.stake!.getStakingContext).toHaveBeenCalledWith({
+          address_id: address.getId(),
+          network_id: address.getNetworkId(),
+          asset_id: Coinbase.assets.Eth,
+          options: {
+            mode: StakeOptionsMode.NATIVE,
+            withdrawal_credential_type: "0x02",
+          },
+        });
+        expect(Coinbase.apiClients.stake!.buildStakingOperation).toHaveBeenCalledWith({
+          address_id: address.getId(),
+          network_id: address.getNetworkId(),
+          asset_id: Coinbase.assets.Eth,
+          action: "stake",
+          options: {
+            mode: StakeOptionsMode.NATIVE,
+            amount: "64000000000000000000",
+            withdrawal_credential_type: "0x02",
+          },
+        });
+
+        expect(op).toBeInstanceOf(StakingOperation);
+      });
+    });
+
     it("should return an error for not enough amount to stake", async () => {
       Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
 
       await expect(
-        address.buildStakeOperation(new Decimal("3.1"), Coinbase.assets.Eth),
+        address.buildStakeOperation(new Decimal("300"), Coinbase.assets.Eth),
       ).rejects.toThrow(Error);
       expect(Coinbase.apiClients.stake!.getStakingContext).toHaveBeenCalledWith({
         address_id: address.getId(),
@@ -688,7 +764,7 @@ describe("ExternalAddress", () => {
     it("should return the stakeable balance successfully with default params", async () => {
       Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
       const stakeableBalance = await address.stakeableBalance(Coinbase.assets.Eth);
-      expect(stakeableBalance).toEqual(new Decimal("3"));
+      expect(stakeableBalance).toEqual(new Decimal("128"));
       expect(Coinbase.apiClients.stake!.getStakingContext).toHaveBeenCalledWith({
         address_id: address.getId(),
         network_id: address.getNetworkId(),
@@ -706,7 +782,7 @@ describe("ExternalAddress", () => {
         StakeOptionsMode.PARTIAL,
         {},
       );
-      expect(stakeableBalance).toEqual(new Decimal("3"));
+      expect(stakeableBalance).toEqual(new Decimal("128"));
       expect(Coinbase.apiClients.stake!.getStakingContext).toHaveBeenCalledWith({
         address_id: address.getId(),
         network_id: address.getNetworkId(),

--- a/src/tests/wallet_address_test.ts
+++ b/src/tests/wallet_address_test.ts
@@ -16,7 +16,7 @@ import {
   StakingRewardFormat,
   StakingRewardStateEnum,
   Trade as TradeModel,
-  TransferList,
+  TransferList
 } from "../client";
 import Decimal from "decimal.js";
 import { APIError, FaucetLimitReachedError } from "../coinbase/api_error";
@@ -61,7 +61,7 @@ import {
   VALID_TRANSFER_MODEL,
   VALID_WALLET_MODEL,
   walletsApiMock,
-  walletStakeApiMock,
+  walletStakeApiMock
 } from "./utils";
 import { Transfer } from "../coinbase/transfer";
 import { StakeOptionsMode, TransactionStatus } from "../coinbase/types";
@@ -69,10 +69,7 @@ import { Trade } from "../coinbase/trade";
 import { Transaction } from "../coinbase/transaction";
 import { WalletAddress } from "../coinbase/address/wallet_address";
 import { Wallet } from "../coinbase/wallet";
-import {
-  ExecutionLayerWithdrawalOptionsBuilder,
-  StakingOperation,
-} from "../coinbase/staking_operation";
+import { ExecutionLayerWithdrawalOptionsBuilder, StakingOperation } from "../coinbase/staking_operation";
 import { StakingReward } from "../coinbase/staking_reward";
 import { StakingBalance } from "../coinbase/staking_balance";
 import { PayloadSignature } from "../coinbase/payload_signature";
@@ -374,7 +371,7 @@ describe("WalletAddress", () => {
     const STAKING_CONTEXT_MODEL: StakingContextModel = {
       context: {
         stakeable_balance: {
-          amount: "3000000000000000000",
+          amount: "128000000000000000000",
           asset: {
             asset_id: Coinbase.assets.Eth,
             network_id: Coinbase.networks.EthereumHolesky,
@@ -533,6 +530,82 @@ describe("WalletAddress", () => {
         expect(op).toBeInstanceOf(StakingOperation);
       });
 
+      describe("native eth staking", () => {
+        it("should successfully create an 0x01 stake operation", async () => {
+          Coinbase.apiClients.asset!.getAsset = getAssetMock();
+          Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
+          Coinbase.apiClients.walletStake!.createStakingOperation =
+            mockReturnValue(STAKING_OPERATION_MODEL);
+          Coinbase.apiClients.walletStake!.broadcastStakingOperation =
+            mockReturnValue(STAKING_OPERATION_MODEL);
+          STAKING_OPERATION_MODEL.status = StakingOperationStatusEnum.Complete;
+          Coinbase.apiClients.walletStake!.getStakingOperation =
+            mockReturnValue(STAKING_OPERATION_MODEL);
+
+          const op = await walletAddress.createStake(
+            32,
+            Coinbase.assets.Eth,
+            StakeOptionsMode.NATIVE,
+            {
+              withdrawal_credential_type: "0x01",
+            },
+          );
+
+          expect(Coinbase.apiClients.walletStake!.createStakingOperation).toHaveBeenCalledWith(
+            walletAddress.getWalletId(),
+            walletAddress.getId(),
+            {
+              network_id: walletAddress.getNetworkId(),
+              asset_id: Coinbase.assets.Eth,
+              action: "stake",
+              options: {
+                mode: StakeOptionsMode.NATIVE,
+                amount: "32000000000000000000",
+                withdrawal_credential_type: "0x01",
+              },
+            },
+          );
+          expect(op).toBeInstanceOf(StakingOperation);
+        });
+
+        it("should successfully create an 0x02 stake operation", async () => {
+          Coinbase.apiClients.asset!.getAsset = getAssetMock();
+          Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
+          Coinbase.apiClients.walletStake!.createStakingOperation =
+            mockReturnValue(STAKING_OPERATION_MODEL);
+          Coinbase.apiClients.walletStake!.broadcastStakingOperation =
+            mockReturnValue(STAKING_OPERATION_MODEL);
+          STAKING_OPERATION_MODEL.status = StakingOperationStatusEnum.Complete;
+          Coinbase.apiClients.walletStake!.getStakingOperation =
+            mockReturnValue(STAKING_OPERATION_MODEL);
+
+          const op = await walletAddress.createStake(
+            64,
+            Coinbase.assets.Eth,
+            StakeOptionsMode.NATIVE,
+            {
+              withdrawal_credential_type: "0x02",
+            },
+          );
+
+          expect(Coinbase.apiClients.walletStake!.createStakingOperation).toHaveBeenCalledWith(
+            walletAddress.getWalletId(),
+            walletAddress.getId(),
+            {
+              network_id: walletAddress.getNetworkId(),
+              asset_id: Coinbase.assets.Eth,
+              action: "stake",
+              options: {
+                mode: StakeOptionsMode.NATIVE,
+                amount: "64000000000000000000",
+                withdrawal_credential_type: "0x02",
+              },
+            },
+          );
+          expect(op).toBeInstanceOf(StakingOperation);
+        });
+      });
+
       it("should create a staking operation from the address but in failed status", async () => {
         Coinbase.apiClients.asset!.getAsset = getAssetMock();
         Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
@@ -659,7 +732,7 @@ describe("WalletAddress", () => {
       it("should return the stakeable balance successfully with default params", async () => {
         Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
         const stakeableBalance = await walletAddress.stakeableBalance(Coinbase.assets.Eth);
-        expect(stakeableBalance).toEqual(new Decimal("3"));
+        expect(stakeableBalance).toEqual(new Decimal("128"));
       });
     });
 


### PR DESCRIPTION
### What changed? Why?

For build and create staking requests fixes a bug where amount was not set when staking native ETH 0x02.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
