### PR TITLE
feat: unify consensus and execution based withdrawals

### DIFF
--- a/src/coinbase/address/external_address.ts
+++ b/src/coinbase/address/external_address.ts
@@ -67,6 +67,7 @@ export class ExternalAddress extends Address {
     if (!IsDedicatedEthUnstakeV2Operation(assetId, "unstake", mode, options)) {
       await this.validateCanUnstake(amount, assetId, mode, options);
     }
+
     return this.buildStakingOperation(amount, assetId, "unstake", mode, options);
   }
 

--- a/src/coinbase/address/wallet_address.ts
+++ b/src/coinbase/address/wallet_address.ts
@@ -26,7 +26,7 @@ import {
 } from "../types";
 import { delay } from "../utils";
 import { Wallet as WalletClass } from "../wallet";
-import { HasWithdrawalCredentialType0x02Option, IsDedicatedEthUnstakeV2Operation, StakingOperation } from "../staking_operation";
+import { IsDedicatedEthUnstakeV2Operation, StakingOperation } from "../staking_operation";
 import { PayloadSignature } from "../payload_signature";
 import { SmartContract } from "../smart_contract";
 import { FundOperation } from "../fund_operation";

--- a/src/coinbase/staking_operation.ts
+++ b/src/coinbase/staking_operation.ts
@@ -10,16 +10,20 @@ import { Amount, StakeOptionsMode } from "./types";
 import { Asset } from "./asset";
 import Decimal from "decimal.js";
 
-export const WithdrawalCredentialType0x02 = "0x02";
+export const UnstakeTypeExecution = "execution";
+export const UnstakeTypeConsensus = "consensus";
 
 /**
- * Checks if the given options contain the withdrawal credential type 0x02.
+ * Checks if the given options contains the unstake type option.
  *
  * @param options - An object containing various options.
- * @returns True if the withdrawal credential type is 0x02, false otherwise.
+ * @returns True if the unstake type is consensus or execution, false otherwise.
  */
-export function HasWithdrawalCredentialType0x02Option(options: { [key: string]: string }): boolean {
-  return options["withdrawal_credential_type"] === WithdrawalCredentialType0x02;
+export function HasUnstakeTypeOption(options: { [key: string]: string }): boolean {
+  return (
+    options["unstake_type"] === UnstakeTypeConsensus ||
+    options["unstake_type"] === UnstakeTypeExecution
+  );
 }
 
 /**
@@ -41,7 +45,7 @@ export function IsDedicatedEthUnstakeV2Operation(
     assetId === Coinbase.assets.Eth &&
     action == "unstake" &&
     mode === StakeOptionsMode.NATIVE &&
-    HasWithdrawalCredentialType0x02Option(options)
+    HasUnstakeTypeOption(options)
   );
 }
 
@@ -363,10 +367,43 @@ export class ExecutionLayerWithdrawalOptionsBuilder {
     }
 
     const executionLayerWithdrawalOptions = {
-      withdrawal_credential_type: WithdrawalCredentialType0x02,
+      unstake_type: UnstakeTypeExecution,
       validator_unstake_amounts: JSON.stringify(validatorAmounts),
     };
 
     return Object.assign({}, options, executionLayerWithdrawalOptions);
+  }
+}
+
+/**
+ * A builder class for creating consensus layer exit options.
+ */
+export class ConsensusLayerExitOptionBuilder {
+  private validatorPubKeys: string[] = [];
+
+  /**
+   * Adds a validator public key to the list of validators.
+   *
+   * @param pubKey - The public key of the validator.
+   */
+  addValidator(pubKey: string) {
+    if (!this.validatorPubKeys.includes(pubKey)) {
+      this.validatorPubKeys.push(pubKey);
+    }
+  }
+
+  /**
+   * Builds the consensus layer exit options.
+   *
+   * @param options - Existing options to merge with the built options.
+   * @returns A promise that resolves to an object containing the consensus layer exit options merged with any provided options.
+   */
+  async build(options: { [key: string]: string } = {}): Promise<{ [key: string]: string }> {
+    const consensusLayerExitOptions = {
+      unstake_type: UnstakeTypeConsensus,
+      validator_pub_keys: this.validatorPubKeys.join(","),
+    };
+
+    return Object.assign({}, options, consensusLayerExitOptions);
   }
 }


### PR DESCRIPTION
### What changed? Why?

This PR helps add support for both consensus and execution based withdrawals for the upcoming Pectra upgrade.

### Testing

Did the following testing in production:

* Setup

```
import { Coinbase, ExternalAddress, StakingReward, StakeOptionsMode, Validator, ValidatorStatus, Transaction, Asset } from "./src";
import { ethers } from "ethers";
import axios from 'axios';
import Decimal from "decimal.js";

const coinbase = Coinbase.configureFromJson({ filePath: "<API-KEY>" });

const provider = new ethers.JsonRpcProvider("<RPC_URL>");

const wallet = new ethers.Wallet("<WALLET_PRIVATE_KEY>");
```

#### 0x02 provisioning

```
let ea = new ExternalAddress("ethereum-hoodi", "0xdb816889F2a7362EF242E5a717dfD5B38Ae849FE");

await ea.stakeableBalance("eth", StakeOptionsMode.NATIVE);

let nativeEthStakeOperation1 = await ea.buildStakeOperation(64, "eth", StakeOptionsMode.NATIVE, {"withdrawal_credential_type": "0x02"});

await nativeEthStakeOperation1.wait();

await nativeEthStakeOperation1.sign(wallet);

nativeEthStakeOperation1.getTransactions().forEach(async tx => {
  let resp = await provider.broadcastTransaction(tx.getSignedPayload()!);
  console.log(resp);
});

await Validator.list("ethereum-hoodi", "eth", ValidatorStatus.DEPOSITED);
```

#### 0x01 provisioning

```
let nativeEthStakeOperation2 = await ea.buildStakeOperation(64, "eth", StakeOptionsMode.NATIVE);

await nativeEthStakeOperation2.wait();

await nativeEthStakeOperation2.sign(wallet);

nativeEthStakeOperation2.getTransactions().forEach(async tx => {
  let resp = await provider.broadcastTransaction(tx.getSignedPayload()!);
  console.log(resp);
});

await Validator.list("ethereum-hoodi", "eth", ValidatorStatus.DEPOSITED);
```

#### Consensus unstaking based on amount

```
await ea.unstakeableBalance("eth", StakeOptionsMode.NATIVE);
await ea.unstakeableBalance("eth", StakeOptionsMode.NATIVE, {"withdrawal_credential_type": "0x02"});

let nativeEthUnstakeOperation1 = await ea.buildUnstakeOperation(32, "eth", StakeOptionsMode.NATIVE);

await nativeEthUnstakeOperation1.wait();

nativeEthUnstakeOperation1.getSignedVoluntaryExitMessages().forEach(async signedVoluntaryExitMessage => {
  let resp = await axios.post("<RPC_URL>/eth/v1/beacon/pool/voluntary_exits", signedVoluntaryExitMessage)
  console.log(resp.status);
});
```

#### Consensus unstaking based on pub keys

```
let nativeEthUnstakeOperation3 = await ea.buildUnstakeOperation(0, "eth", StakeOptionsMode.NATIVE, {"validator_pub_keys": "0x91d28dd6bd2cada7acbd6f018fd05c573f712fb39a81296508f666dff0ebd0673d2c02296042feb923deb247a9d894a9,0xa20c0e64f20fd301b0603a152eb0295dbc8d9136344538f7ae1d8b68afc53d79adbbaa882db4e3dd6f83799116fcd6e7"});

await nativeEthUnstakeOperation3.wait();
```

#### Execution unstaking

```
let builder = new ExecutionLayerWithdrawalOptionsBuilder(ea.getNetworkId());
builder.addValidatorWithdrawal("0xa93d28460d56e4af0b87bba27dbef27d69eb1ba5101a50d5d920844e5e196efd0ea830bce5a68b18a8c035dd343a517d", new Decimal("1"));
builder.addValidatorWithdrawal("0xa20c0e64f20fd301b0603a152eb0295dbc8d9136344538f7ae1d8b68afc53d79adbbaa882db4e3dd6f83799116fcd6e7", new Decimal("2"));

let options = await builder.build();

let nativeEthUnstakeOperation4 = await ea.buildUnstakeOperation(0, "eth", StakeOptionsMode.NATIVE, options);

await nativeEthUnstakeOperation4.wait();

await nativeEthUnstakeOperation4.sign(wallet);

nativeEthUnstakeOperation4.getTransactions().forEach(async tx => {
  let resp = await provider.broadcastTransaction(tx.getSignedPayload()!);
  console.log(resp);
});
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
