### PR TITLE
feat: Remove support for Holesky

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -2363,7 +2363,6 @@ export type NetworkProtocolFamilyEnum = typeof NetworkProtocolFamilyEnum[keyof t
 export const NetworkIdentifier = {
     BaseSepolia: 'base-sepolia',
     BaseMainnet: 'base-mainnet',
-    EthereumHolesky: 'ethereum-holesky',
     EthereumHoodi: 'ethereum-hoodi',
     EthereumSepolia: 'ethereum-sepolia',
     EthereumMainnet: 'ethereum-mainnet',

--- a/src/tests/address_test.ts
+++ b/src/tests/address_test.ts
@@ -13,7 +13,7 @@ import Decimal from "decimal.js";
 import { randomUUID } from "crypto";
 
 describe("Address", () => {
-  const newAddress = newAddressModel("", randomUUID(), Coinbase.networks.EthereumHolesky);
+  const newAddress = newAddressModel("", randomUUID(), Coinbase.networks.EthereumHoodi);
 
   const address = new Address(newAddress.network_id, newAddress.address_id);
 
@@ -147,7 +147,7 @@ describe("Address", () => {
             block_height: "12345",
             asset: {
               asset_id: "usdc",
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 6,
             },
           },
@@ -157,7 +157,7 @@ describe("Address", () => {
             block_height: "67890",
             asset: {
               asset_id: "usdc",
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 6,
             },
           },
@@ -242,7 +242,7 @@ describe("Address", () => {
             block_height: "67890",
             asset: {
               asset_id: "usdc",
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 6,
             },
           },

--- a/src/tests/external_address_test.ts
+++ b/src/tests/external_address_test.ts
@@ -33,7 +33,7 @@ import { StakingReward } from "../coinbase/staking_reward";
 import { StakingBalance } from "../coinbase/staking_balance";
 
 describe("ExternalAddress", () => {
-  const newAddress = newAddressModel("", randomUUID(), Coinbase.networks.EthereumHolesky);
+  const newAddress = newAddressModel("", randomUUID(), Coinbase.networks.EthereumHoodi);
 
   const address = new ExternalAddress(newAddress.network_id, newAddress.address_id);
   const STAKING_CONTEXT_MODEL: StakingContextModel = {
@@ -42,7 +42,7 @@ describe("ExternalAddress", () => {
         amount: "128000000000000000000",
         asset: {
           asset_id: Coinbase.assets.Eth,
-          network_id: Coinbase.networks.EthereumHolesky,
+          network_id: Coinbase.networks.EthereumHoodi,
           decimals: 18,
           contract_address: "0x",
         },
@@ -51,7 +51,7 @@ describe("ExternalAddress", () => {
         amount: "2000000000000000000",
         asset: {
           asset_id: Coinbase.assets.Eth,
-          network_id: Coinbase.networks.EthereumHolesky,
+          network_id: Coinbase.networks.EthereumHoodi,
           decimals: 18,
           contract_address: "0x",
         },
@@ -60,7 +60,7 @@ describe("ExternalAddress", () => {
         amount: "1000000000000000000",
         asset: {
           asset_id: Coinbase.assets.Eth,
-          network_id: Coinbase.networks.EthereumHolesky,
+          network_id: Coinbase.networks.EthereumHoodi,
           decimals: 18,
           contract_address: "0x",
         },
@@ -69,7 +69,7 @@ describe("ExternalAddress", () => {
         amount: "1000000000000000000",
         asset: {
           asset_id: Coinbase.assets.Eth,
-          network_id: Coinbase.networks.EthereumHolesky,
+          network_id: Coinbase.networks.EthereumHoodi,
           decimals: 18,
           contract_address: "0x",
         },
@@ -78,7 +78,7 @@ describe("ExternalAddress", () => {
   };
   const STAKING_OPERATION_MODEL: StakingOperationModel = {
     id: randomUUID(),
-    network_id: Coinbase.networks.EthereumHolesky,
+    network_id: Coinbase.networks.EthereumHoodi,
     address_id: "0x1234567890",
     status: StakingOperationStatusEnum.Initialized,
     transactions: [
@@ -654,7 +654,7 @@ describe("ExternalAddress", () => {
             amount: "1000000000000000000",
             asset: {
               asset_id: Coinbase.assets.Eth,
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 18,
             },
           },
@@ -662,7 +662,7 @@ describe("ExternalAddress", () => {
             amount: "5000000",
             asset: {
               asset_id: "usdc",
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 6,
             },
           },
@@ -714,7 +714,7 @@ describe("ExternalAddress", () => {
         amount: "5000000000000000000",
         asset: {
           asset_id: Coinbase.assets.Eth,
-          network_id: Coinbase.networks.EthereumHolesky,
+          network_id: Coinbase.networks.EthereumHoodi,
           decimals: 18,
         },
       };

--- a/src/tests/stake_test.ts
+++ b/src/tests/stake_test.ts
@@ -97,17 +97,17 @@ describe("Validator", () => {
     });
   });
 
-  it("should return a list of validators for ethereum holesky and eth asset", async () => {
+  it("should return a list of validators for ethereum hoodi and eth asset", async () => {
     Coinbase.apiClients.stake!.listValidators = mockReturnValue(VALID_ACTIVE_VALIDATOR_LIST);
 
     const validators = await Validator.list(
-      Coinbase.networks.EthereumHolesky,
+      Coinbase.networks.EthereumHoodi,
       Coinbase.assets.Eth,
       ValidatorStatus.ACTIVE,
     );
 
     expect(Coinbase.apiClients.stake!.listValidators).toHaveBeenCalledWith(
-      Coinbase.networks.EthereumHolesky,
+      Coinbase.networks.EthereumHoodi,
       Coinbase.assets.Eth,
       ValidatorStatus.ACTIVE,
     );
@@ -121,19 +121,19 @@ describe("Validator", () => {
     expect(validators[2].getStatus()).toEqual(ValidatorStatus.ACTIVE);
   });
 
-  it("should return a validator for ethereum holesky and eth asset", async () => {
+  it("should return a validator for ethereum hoodi and eth asset", async () => {
     Coinbase.apiClients.stake!.getValidator = mockReturnValue(
       mockEthereumValidator("100", ValidatorStatus.EXITING, "0x123"),
     );
 
     const validator = await Validator.fetch(
-      Coinbase.networks.EthereumHolesky,
+      Coinbase.networks.EthereumHoodi,
       Coinbase.assets.Eth,
       "0x123",
     );
 
     expect(Coinbase.apiClients.stake!.getValidator).toHaveBeenCalledWith(
-      Coinbase.networks.EthereumHolesky,
+      Coinbase.networks.EthereumHoodi,
       Coinbase.assets.Eth,
       "0x123",
     );

--- a/src/tests/staking_historical_balance_test.ts
+++ b/src/tests/staking_historical_balance_test.ts
@@ -14,7 +14,7 @@ import { ExternalAddress } from "../coinbase/address/external_address";
 describe("StakingBalance", () => {
   const startTime = "2024-05-01T00:00:00Z";
   const endTime = "2024-05-21T00:00:00Z";
-  const newAddress = newAddressModel("", "some-address-id", Coinbase.networks.EthereumHolesky);
+  const newAddress = newAddressModel("", "some-address-id", Coinbase.networks.EthereumHoodi);
   const address = new ExternalAddress(newAddress.network_id, newAddress.address_id);
   const asset = {
     asset_id: Coinbase.assets.Eth,

--- a/src/tests/staking_operation_test.ts
+++ b/src/tests/staking_operation_test.ts
@@ -35,7 +35,7 @@ describe("StakingOperation", () => {
 
   it("should return a string representation with id, status, network_id, and address_id", () => {
     const op = new StakingOperation(VALID_STAKING_OPERATION_MODEL);
-    const expectedString = `StakingOperation { id: some-id status: initialized network_id: ethereum-holesky address_id: some-address-id }`;
+    const expectedString = `StakingOperation { id: some-id status: initialized network_id: ethereum-hoodi address_id: some-address-id }`;
     expect(op.toString()).toEqual(expectedString);
   });
 
@@ -184,7 +184,7 @@ describe("StakingOperation", () => {
       const stakingOperation = new StakingOperation(VALID_STAKING_OPERATION_MODEL);
       expect(stakingOperation.getID()).toBe("some-id");
       expect(stakingOperation.getStatus()).toBe(StakingOperationStatusEnum.Initialized);
-      expect(stakingOperation.getNetworkID()).toBe(Coinbase.networks.EthereumHolesky);
+      expect(stakingOperation.getNetworkID()).toBe(Coinbase.networks.EthereumHoodi);
       expect(stakingOperation.isTerminalState()).toBe(false);
       expect(stakingOperation.getTransactions().length).toBe(1);
       expect(stakingOperation.getSignedVoluntaryExitMessages().length).toBe(0);
@@ -198,7 +198,7 @@ describe("StakingOperation", () => {
         ...VALID_STAKING_OPERATION_MODEL,
         transactions: [
           {
-            network_id: Coinbase.networks.EthereumHolesky,
+            network_id: Coinbase.networks.EthereumHoodi,
             from_address_id: "dummy-from-address-id",
             to_address_id: "dummy-to-address-id",
             unsigned_payload: "payload1",
@@ -207,7 +207,7 @@ describe("StakingOperation", () => {
             status: TransactionStatusEnum.Pending,
           },
           {
-            network_id: Coinbase.networks.EthereumHolesky,
+            network_id: Coinbase.networks.EthereumHoodi,
             from_address_id: "dummy-from-address-id",
             to_address_id: "dummy-to-address-id",
             unsigned_payload: "payload2",
@@ -216,7 +216,7 @@ describe("StakingOperation", () => {
             status: TransactionStatusEnum.Pending,
           },
           {
-            network_id: Coinbase.networks.EthereumHolesky,
+            network_id: Coinbase.networks.EthereumHoodi,
             from_address_id: "dummy-from-address-id",
             to_address_id: "dummy-to-address-id",
             unsigned_payload: "payload3",
@@ -240,7 +240,7 @@ describe("StakingOperation", () => {
       // Step 3: Call reload and add two new transactions (payload4 and payload5)
       op["model"].transactions.push(
         {
-          network_id: Coinbase.networks.EthereumHolesky,
+          network_id: Coinbase.networks.EthereumHoodi,
           from_address_id: "dummy-from-address-id",
           to_address_id: "dummy-to-address-id",
           unsigned_payload: "payload4",
@@ -249,7 +249,7 @@ describe("StakingOperation", () => {
           status: TransactionStatusEnum.Pending,
         },
         {
-          network_id: Coinbase.networks.EthereumHolesky,
+          network_id: Coinbase.networks.EthereumHoodi,
           from_address_id: "dummy-from-address-id",
           to_address_id: "dummy-to-address-id",
           unsigned_payload: "payload5",

--- a/src/tests/staking_reward_test.ts
+++ b/src/tests/staking_reward_test.ts
@@ -17,7 +17,7 @@ import Decimal from "decimal.js";
 describe("StakingReward", () => {
   const startTime = "2024-05-01T00:00:00Z";
   const endTime = "2024-05-21T00:00:00Z";
-  const newAddress = newAddressModel("", "some-address-id", Coinbase.networks.EthereumHolesky);
+  const newAddress = newAddressModel("", "some-address-id", Coinbase.networks.EthereumHoodi);
   const address = new ExternalAddress(newAddress.network_id, newAddress.address_id);
   const asset = Asset.fromModel({
     asset_id: Coinbase.assets.Eth,

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -225,12 +225,12 @@ export const VALID_TRANSFER_SPONSORED_SEND_MODEL: TransferModel = {
 
 export const VALID_STAKING_OPERATION_MODEL: StakingOperationModel = {
   id: "some-id",
-  network_id: Coinbase.networks.EthereumHolesky,
+  network_id: Coinbase.networks.EthereumHoodi,
   address_id: "some-address-id",
   status: StakingOperationStatusEnum.Initialized,
   transactions: [
     {
-      network_id: Coinbase.networks.EthereumHolesky,
+      network_id: Coinbase.networks.EthereumHoodi,
       from_address_id: "dummy-from-address-id",
       to_address_id: "dummy-to-address-id",
       unsigned_payload:
@@ -559,12 +559,12 @@ export const VALID_FUND_OPERATION_MODEL: FundOperationModel = {
 export function mockStakingOperation(status: StakingOperationStatusEnum): StakingOperationModel {
   return {
     id: "some-id",
-    network_id: Coinbase.networks.EthereumHolesky,
+    network_id: Coinbase.networks.EthereumHoodi,
     address_id: "some-address-id",
     status: status,
     transactions: [
       {
-        network_id: Coinbase.networks.EthereumHolesky,
+        network_id: Coinbase.networks.EthereumHoodi,
         from_address_id: "0xdeadbeef",
         unsigned_payload:
           "7b2274797065223a22307832222c22636861696e4964223a2230783134613334222c226e6f6e63" +
@@ -652,7 +652,7 @@ export function mockEthereumValidator(
 ): Validator {
   return {
     validator_id: public_key,
-    network_id: "ethereum-holesky",
+    network_id: "ethereum-hoodi",
     asset_id: "eth",
     status: status,
     details: {
@@ -670,14 +670,14 @@ export function mockEthereumValidator(
         amount: "32000000000000000000",
         asset: {
           asset_id: Coinbase.assets.Eth,
-          network_id: Coinbase.networks.EthereumHolesky,
+          network_id: Coinbase.networks.EthereumHoodi,
         },
       },
       effective_balance: {
         amount: "32000000000000000000",
         asset: {
           asset_id: Coinbase.assets.Eth,
-          network_id: Coinbase.networks.EthereumHolesky,
+          network_id: Coinbase.networks.EthereumHoodi,
         },
       },
     },

--- a/src/tests/validator_test.ts
+++ b/src/tests/validator_test.ts
@@ -11,16 +11,16 @@ describe("Validator", () => {
     const mockModel: ValidatorModel = {
       validator_id: "123",
       status: APIValidatorStatus.Active,
-      network_id: Coinbase.networks.EthereumHolesky,
+      network_id: Coinbase.networks.EthereumHoodi,
       asset_id: Coinbase.assets.Eth,
       details: {
         effective_balance: {
           amount: "100",
-          asset: { network_id: Coinbase.networks.EthereumHolesky, asset_id: Coinbase.assets.Eth },
+          asset: { network_id: Coinbase.networks.EthereumHoodi, asset_id: Coinbase.assets.Eth },
         },
         balance: {
           amount: "200",
-          asset: { network_id: Coinbase.networks.EthereumHolesky, asset_id: Coinbase.assets.Eth },
+          asset: { network_id: Coinbase.networks.EthereumHoodi, asset_id: Coinbase.assets.Eth },
         },
         exitEpoch: "epoch-1",
         activationEpoch: "epoch-0",
@@ -46,7 +46,7 @@ describe("Validator", () => {
   });
 
   test("getNetworkId should return the correct network ID", () => {
-    expect(validator.getNetworkId()).toBe(Coinbase.networks.EthereumHolesky);
+    expect(validator.getNetworkId()).toBe(Coinbase.networks.EthereumHoodi);
   });
 
   test("getAssetId should return the correct asset ID", () => {
@@ -96,14 +96,14 @@ describe("Validator", () => {
   test("getEffectiveBalance should return the correct effective balance", () => {
     expect(validator.getEffectiveBalance()).toEqual({
       amount: "100",
-      asset: { network_id: Coinbase.networks.EthereumHolesky, asset_id: Coinbase.assets.Eth },
+      asset: { network_id: Coinbase.networks.EthereumHoodi, asset_id: Coinbase.assets.Eth },
     });
   });
 
   test("getBalance should return the correct balance", () => {
     expect(validator.getBalance()).toEqual({
       amount: "200",
-      asset: { network_id: Coinbase.networks.EthereumHolesky, asset_id: Coinbase.assets.Eth },
+      asset: { network_id: Coinbase.networks.EthereumHoodi, asset_id: Coinbase.assets.Eth },
     });
   });
 });

--- a/src/tests/wallet_address_test.ts
+++ b/src/tests/wallet_address_test.ts
@@ -344,17 +344,17 @@ describe("WalletAddress", () => {
 
   describe("#stakingOperation", () => {
     key = ethers.Wallet.createRandom();
-    const newAddress = newAddressModel("", randomUUID(), Coinbase.networks.EthereumHolesky);
+    const newAddress = newAddressModel("", randomUUID(), Coinbase.networks.EthereumHoodi);
     const walletAddress = new WalletAddress(newAddress, key as unknown as ethers.Wallet);
     const STAKING_OPERATION_MODEL: StakingOperationModel = {
       id: randomUUID(),
-      network_id: Coinbase.networks.EthereumHolesky,
+      network_id: Coinbase.networks.EthereumHoodi,
       address_id: newAddress.address_id,
       status: StakingOperationStatusEnum.Complete,
       transactions: [
         {
           from_address_id: newAddress.address_id,
-          network_id: Coinbase.networks.EthereumHolesky,
+          network_id: Coinbase.networks.EthereumHoodi,
           status: "pending",
           unsigned_payload:
             "7b2274797065223a22307832222c22636861696e4964223a22307834323638222c226e6f" +
@@ -378,7 +378,7 @@ describe("WalletAddress", () => {
           amount: "128000000000000000000",
           asset: {
             asset_id: Coinbase.assets.Eth,
-            network_id: Coinbase.networks.EthereumHolesky,
+            network_id: Coinbase.networks.EthereumHoodi,
             decimals: 18,
             contract_address: "0x",
           },
@@ -387,7 +387,7 @@ describe("WalletAddress", () => {
           amount: "2000000000000000000",
           asset: {
             asset_id: Coinbase.assets.Eth,
-            network_id: Coinbase.networks.EthereumHolesky,
+            network_id: Coinbase.networks.EthereumHoodi,
             decimals: 18,
             contract_address: "0x",
           },
@@ -396,7 +396,7 @@ describe("WalletAddress", () => {
           amount: "1000000000000000000",
           asset: {
             asset_id: Coinbase.assets.Eth,
-            network_id: Coinbase.networks.EthereumHolesky,
+            network_id: Coinbase.networks.EthereumHoodi,
             decimals: 18,
             contract_address: "0x",
           },
@@ -405,7 +405,7 @@ describe("WalletAddress", () => {
           amount: "1000000000000000000",
           asset: {
             asset_id: Coinbase.assets.Eth,
-            network_id: Coinbase.networks.EthereumHolesky,
+            network_id: Coinbase.networks.EthereumHoodi,
             decimals: 18,
             contract_address: "0x",
           },
@@ -465,7 +465,7 @@ describe("WalletAddress", () => {
             amount: "32000000000000000000",
             asset: {
               asset_id: Coinbase.assets.Eth,
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 18,
             },
           },
@@ -473,7 +473,7 @@ describe("WalletAddress", () => {
             amount: "2000000000000000000",
             asset: {
               asset_id: Coinbase.assets.Eth,
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 18,
             },
           },
@@ -486,7 +486,7 @@ describe("WalletAddress", () => {
             amount: "34000000000000000000",
             asset: {
               asset_id: Coinbase.assets.Eth,
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 18,
             },
           },
@@ -494,7 +494,7 @@ describe("WalletAddress", () => {
             amount: "3000000000000000000",
             asset: {
               asset_id: Coinbase.assets.Eth,
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 18,
             },
           },
@@ -848,14 +848,12 @@ describe("WalletAddress", () => {
         expect(response[0].bondedStake().amount).toEqual(new Decimal("32"));
         expect(response[0].bondedStake().asset?.assetId).toEqual(Coinbase.assets.Eth);
         expect(response[0].bondedStake().asset?.decimals).toEqual(18);
-        expect(response[0].bondedStake().asset?.networkId).toEqual(
-          Coinbase.networks.EthereumHolesky,
-        );
+        expect(response[0].bondedStake().asset?.networkId).toEqual(Coinbase.networks.EthereumHoodi);
         expect(response[0].unbondedBalance().amount).toEqual(new Decimal("2"));
         expect(response[0].unbondedBalance().asset?.assetId).toEqual(Coinbase.assets.Eth);
         expect(response[0].unbondedBalance().asset?.decimals).toEqual(18);
         expect(response[0].unbondedBalance().asset?.networkId).toEqual(
-          Coinbase.networks.EthereumHolesky,
+          Coinbase.networks.EthereumHoodi,
         );
       });
     });

--- a/src/tests/wallet_test.ts
+++ b/src/tests/wallet_test.ts
@@ -124,13 +124,13 @@ describe("Wallet Class", () => {
     const addressID = "0xdeadbeef";
     const STAKING_OPERATION_MODEL: StakingOperationModel = {
       id: randomUUID(),
-      network_id: Coinbase.networks.EthereumHolesky,
+      network_id: Coinbase.networks.EthereumHoodi,
       address_id: addressID,
       status: StakingOperationStatusEnum.Complete,
       transactions: [
         {
           from_address_id: addressID,
-          network_id: Coinbase.networks.EthereumHolesky,
+          network_id: Coinbase.networks.EthereumHoodi,
           status: "pending",
           unsigned_payload:
             "7b2274797065223a22307832222c22636861696e4964223a22307834323638222c226e6f" +
@@ -154,7 +154,7 @@ describe("Wallet Class", () => {
           amount: "3000000000000000000",
           asset: {
             asset_id: Coinbase.assets.Eth,
-            network_id: Coinbase.networks.EthereumHolesky,
+            network_id: Coinbase.networks.EthereumHoodi,
             decimals: 18,
             contract_address: "0x",
           },
@@ -163,7 +163,7 @@ describe("Wallet Class", () => {
           amount: "2000000000000000000",
           asset: {
             asset_id: Coinbase.assets.Eth,
-            network_id: Coinbase.networks.EthereumHolesky,
+            network_id: Coinbase.networks.EthereumHoodi,
             decimals: 18,
             contract_address: "0x",
           },
@@ -172,7 +172,7 @@ describe("Wallet Class", () => {
           amount: "1000000000000000000",
           asset: {
             asset_id: Coinbase.assets.Eth,
-            network_id: Coinbase.networks.EthereumHolesky,
+            network_id: Coinbase.networks.EthereumHoodi,
             decimals: 18,
             contract_address: "0x",
           },
@@ -181,7 +181,7 @@ describe("Wallet Class", () => {
           amount: "1000000000000000000",
           asset: {
             asset_id: Coinbase.assets.Eth,
-            network_id: Coinbase.networks.EthereumHolesky,
+            network_id: Coinbase.networks.EthereumHoodi,
             decimals: 18,
             contract_address: "0x",
           },
@@ -241,7 +241,7 @@ describe("Wallet Class", () => {
             amount: "32000000000000000000",
             asset: {
               asset_id: Coinbase.assets.Eth,
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 18,
             },
           },
@@ -249,7 +249,7 @@ describe("Wallet Class", () => {
             amount: "2000000000000000000",
             asset: {
               asset_id: Coinbase.assets.Eth,
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 18,
             },
           },
@@ -262,7 +262,7 @@ describe("Wallet Class", () => {
             amount: "32000000000000000000",
             asset: {
               asset_id: Coinbase.assets.Eth,
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 18,
             },
           },
@@ -270,7 +270,7 @@ describe("Wallet Class", () => {
             amount: "2000000000000000000",
             asset: {
               asset_id: Coinbase.assets.Eth,
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 18,
             },
           },
@@ -293,7 +293,7 @@ describe("Wallet Class", () => {
 
     describe(".createStake", () => {
       it("should create a staking operation from the default address", async () => {
-        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
+        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHoodi });
         STAKING_OPERATION_MODEL.wallet_id = wallet.getId();
         Coinbase.apiClients.asset!.getAsset = getAssetMock();
         Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
@@ -311,7 +311,7 @@ describe("Wallet Class", () => {
       });
 
       it("should throw an error when wait is called on wallet address based staking operation", async () => {
-        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
+        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHoodi });
         const op = await wallet.createStake(0.001, Coinbase.assets.Eth);
         expect(op).toBeInstanceOf(StakingOperation);
         await expect(async () => await op.wait()).rejects.toThrow(Error);
@@ -326,7 +326,7 @@ describe("Wallet Class", () => {
 
     describe(".createUnstake", () => {
       it("should create a staking operation from the default address", async () => {
-        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
+        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHoodi });
         STAKING_OPERATION_MODEL.wallet_id = wallet.getId();
         Coinbase.apiClients.asset!.getAsset = getAssetMock();
         Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
@@ -346,7 +346,7 @@ describe("Wallet Class", () => {
 
     describe(".createClaimStake", () => {
       it("should create a staking operation from the default address", async () => {
-        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
+        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHoodi });
         STAKING_OPERATION_MODEL.wallet_id = wallet.getId();
         Coinbase.apiClients.asset!.getAsset = getAssetMock();
         Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
@@ -374,7 +374,7 @@ describe("Wallet Class", () => {
 
     describe(".unstakeableBalance", () => {
       it("should return the unstakeableBalance balance successfully with default params", async () => {
-        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
+        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHoodi });
         Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
         const stakeableBalance = await wallet.unstakeableBalance(Coinbase.assets.Eth);
         expect(stakeableBalance).toEqual(new Decimal("2"));
@@ -383,7 +383,7 @@ describe("Wallet Class", () => {
 
     describe(".claimableBalance", () => {
       it("should return the claimableBalance balance successfully with default params", async () => {
-        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
+        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHoodi });
         Coinbase.apiClients.stake!.getStakingContext = mockReturnValue(STAKING_CONTEXT_MODEL);
         const stakeableBalance = await wallet.claimableBalance(Coinbase.assets.Eth);
         expect(stakeableBalance).toEqual(new Decimal("1"));
@@ -392,7 +392,7 @@ describe("Wallet Class", () => {
 
     describe(".stakingRewards", () => {
       it("should successfully return staking rewards", async () => {
-        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
+        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHoodi });
         Coinbase.apiClients.stake!.fetchStakingRewards = mockReturnValue(STAKING_REWARD_RESPONSE);
         Coinbase.apiClients.asset!.getAsset = getAssetMock();
         const response = await wallet.stakingRewards(Coinbase.assets.Eth);
@@ -402,7 +402,7 @@ describe("Wallet Class", () => {
 
     describe(".historicalStakingBalances", () => {
       it("should successfully return historical staking balances", async () => {
-        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
+        const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHoodi });
         Coinbase.apiClients.stake!.fetchHistoricalStakingBalances = mockReturnValue(
           HISTORICAL_STAKING_BALANCES_RESPONSE,
         );
@@ -413,14 +413,12 @@ describe("Wallet Class", () => {
         expect(response[0].bondedStake().amount).toEqual(new Decimal("32"));
         expect(response[0].bondedStake().asset?.assetId).toEqual("eth");
         expect(response[0].bondedStake().asset?.decimals).toEqual(18);
-        expect(response[0].bondedStake().asset?.networkId).toEqual(
-          Coinbase.networks.EthereumHolesky,
-        );
+        expect(response[0].bondedStake().asset?.networkId).toEqual(Coinbase.networks.EthereumHoodi);
         expect(response[0].unbondedBalance().amount).toEqual(new Decimal("2"));
         expect(response[0].unbondedBalance().asset?.assetId).toEqual("eth");
         expect(response[0].unbondedBalance().asset?.decimals).toEqual(18);
         expect(response[0].unbondedBalance().asset?.networkId).toEqual(
-          Coinbase.networks.EthereumHolesky,
+          Coinbase.networks.EthereumHoodi,
         );
       });
     });
@@ -436,7 +434,7 @@ describe("Wallet Class", () => {
             block_height: "12345",
             asset: {
               asset_id: "usdc",
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 6,
             },
           },
@@ -446,7 +444,7 @@ describe("Wallet Class", () => {
             block_height: "67890",
             asset: {
               asset_id: "usdc",
-              network_id: Coinbase.networks.EthereumHolesky,
+              network_id: Coinbase.networks.EthereumHoodi,
               decimals: 6,
             },
           },
@@ -461,7 +459,7 @@ describe("Wallet Class", () => {
     });
 
     it("should successfully return historical balances", async () => {
-      const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHolesky });
+      const wallet = await Wallet.create({ networkId: Coinbase.networks.EthereumHoodi });
       Coinbase.apiClients.asset!.getAsset = getAssetMock();
       const response = await wallet.listHistoricalBalances(Coinbase.assets.Usdc);
       expect(response.data.length).toEqual(2);


### PR DESCRIPTION
### What changed? Why?

This PR helps deprecate support for testnet Holesky. It has now been replaced by Hoodi for both shared and dedicated eth staking.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
