### PR TITLE
fix: enable batching in mass-payout.js by deferring transfer.wait()

### DIFF
--- a/quickstart-template/mass-payout.js
+++ b/quickstart-template/mass-payout.js
@@ -59,12 +59,14 @@ async function sendMassPayout(sendingWallet) {
   // Define amount to send.
   const transferAmount = 0.000002;
   const assetId = Coinbase.assets.Eth;
+  const transfers = [];
 
   try {
     const parser = fs
       .createReadStream("./wallet-array.csv")
       .pipe(parse({ delimiter: ",", from_line: 1 }));
 
+    // STEP 1: Queue all transfers (sequentially to enable batching)
     for await (const row of parser) {
       const address = row[0];
       if (address) {
@@ -76,12 +78,21 @@ async function sendMassPayout(sendingWallet) {
             destination: address,
           });
 
-          await transfer.wait();
-
-          console.log(`Transfer to ${address} successful`);
+          transfers.push({ address, transfer });
+          console.log(`Queued transfer to ${address}`);
         } catch (error) {
-          console.error(`Error transferring to ${address}: `, error);
+          console.error(`Error creating transfer to ${address}: `, error);
         }
+      }
+    }
+
+    // STEP 2: Wait for all transfers to complete
+    for (const { address, transfer } of transfers) {
+      try {
+        await transfer.wait();
+        console.log(`Transfer to ${address} successful`);
+      } catch (error) {
+        console.error(`Error waiting for transfer to ${address}: `, error);
       }
     }
   } catch (error) {


### PR DESCRIPTION
## Problem
The current implementation calls `await transfer.wait()` inside the loop, which blocks each transfer from being batched. This serializes all transfers and significantly reduces throughput.

## Solution
1. Collect all transfers in an array first (without waiting)
2. Wait for all transfers to complete after queueing

This enables proper batching as the SDK can process multiple transfers concurrently.

## Changes
- Added `transfers` array to store pending transfers
- Separated transfer creation from completion waiting
- Improved error handling for both phases

## Testing
This change maintains the same behavior while improving performance for mass payouts.

Fixes #416