### PR TITLE
fix(quickstart): enable batching in mass-payout.js

### DIFF
--- a/quickstart-template/mass-payout.js
+++ b/quickstart-template/mass-payout.js
@@ -56,15 +56,17 @@ async function createAndFundSendingWallet() {
 
 // Read from CSV file and send mass payout.
 async function sendMassPayout(sendingWallet) {
-  // Define amount to send.
+  // Define amount and assetId for transfer.
   const transferAmount = 0.000002;
   const assetId = Coinbase.assets.Eth;
+  const transfers = [];
 
   try {
     const parser = fs
       .createReadStream("./wallet-array.csv")
       .pipe(parse({ delimiter: ",", from_line: 1 }));
 
+    // STEP 1: Queue all transfers without waiting for confirmation (enables batching)
     for await (const row of parser) {
       const address = row[0];
       if (address) {
@@ -76,12 +78,22 @@ async function sendMassPayout(sendingWallet) {
             destination: address,
           });
 
-          await transfer.wait();
-
-          console.log(`Transfer to ${address} successful`);
+          transfers.push({ address, transfer });
+          console.log(`Queued transfer to ${address}`);
         } catch (error) {
-          console.error(`Error transferring to ${address}: `, error);
+          console.error(`Error creating transfer to ${address}: `, error);
         }
+      }
+    }
+
+    // STEP 2: Wait for all transfers to complete
+    console.log(`\nWaiting for ${transfers.length} transfers to complete...`);
+    for (const { address, transfer } of transfers) {
+      try {
+        await transfer.wait();
+        console.log(`Transfer to ${address} successful`);
+      } catch (error) {
+        console.error(`Transfer to ${address} failed: `, error);
       }
     }
   } catch (error) {


### PR DESCRIPTION
## Problem
The `sendMassPayout` function was awaiting each transfer inside the for-await loop (line 79), which prevented the SDK from batching transfers efficiently. This caused sequential processing instead of parallel execution.

## Solution
- Collect all transfers in an array first
- Wait for all transfers to complete after queuing
- This allows the SDK to batch operations and improves performance when processing multiple payouts

## Changes
- Added `pendingTransfers` array to store transfer objects
- Queue all transfers first without blocking
- Process completion checks after all transfers are queued
- Improved error handling with clearer log messages

## Testing
This is a quickstart template change. The logic maintains the same functionality while improving performance.

Fixes #416